### PR TITLE
Add support for session {un,}registering.

### DIFF
--- a/rc/kak-tree-sitter.kak
+++ b/rc/kak-tree-sitter.kak
@@ -1,6 +1,15 @@
 # This file should be read only once. Either place it in your autoload/, or use the more practical --kakoune option when
 # invoking kak-tree-sitter.
 
+# Mark the session as non-active.
+#
+# This is typically sent when a session is about to die; see KakEnd for further details.
+define-command -override kak-tree-sitter-end-session -docstring 'Mark the session as ended' %{
+  nop %sh{
+    kak-tree-sitter -s $kak_session -r '{"type":"session_end"}'
+  }
+}
+
 # Stop the kak-tree-sitter daemon.
 #
 # To restart the daemon, the daemon must explicitly be recreated with %sh{kak-tree-sitter -d -s $kak_session}.
@@ -48,6 +57,9 @@ hook -group kak-tree-sitter global WinCreate .* %{
     }
   }
 }
+
+# Make kak-tree-sitter know the session has ended whenever we end it.
+hook -group kak-tree-sitter global KakEnd .* kak-tree-sitter-end-session
 
 # Faces definition
 #set-face global ts_unknown                    red+ub

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -34,7 +34,7 @@ impl Daemon {
     // ensure we have a directory to write in
     let daemon_dir = Self::daemon_dir();
     fs::create_dir_all(&daemon_dir).unwrap(); // FIXME: error
-    eprintln!("daemon in {}", daemon_dir.display());
+    eprintln!("running in {}", daemon_dir.display());
 
     // PID file
     let pid_file = daemon_dir.join("pid");
@@ -42,7 +42,7 @@ impl Daemon {
     // check whether the PID file is already there; if so, it means the daemon is already running, so we will just
     // stop right away
     if let Ok(true) = pid_file.try_exists() {
-      eprintln!("kak-tree-sitter daemon already running; exiting");
+      eprintln!("kak-tree-sitter already running; exiting");
       return;
     }
 
@@ -87,11 +87,11 @@ impl Daemon {
         let resp = req_handler.handle_request(request);
 
         if let Some((mut session, resp)) = resp {
-          session.send_response(&resp);
-
           if let Response::Shutdown = resp {
             break;
           }
+
+          session.send_response(&resp);
         }
       }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,8 +10,6 @@ mod request;
 mod response;
 mod session;
 
-use std::process::exit;
-
 use clap::Parser;
 use cli::Cli;
 use config::Config;
@@ -23,19 +21,12 @@ fn main() {
   let cli = Cli::parse();
   let config = Config::load_from_xdg();
 
-  // we will always need a session name
-  if cli.session.is_none() {
-    eprintln!("missing session name");
-    exit(1);
-  }
-  let session = cli.session.unwrap();
-
   if cli.kakoune {
     // inject the rc/ and daemon-based settings
     println!("{}", rc::rc_commands());
   }
 
-  if let Some(request) = cli.request {
+  if let (Some(session), Some(request)) = (cli.session, cli.request) {
     // client logic
     let kak_sess = KakSession::new(session, cli.client);
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -21,6 +21,11 @@ impl Request {
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum RequestPayload {
+  /// A session just ended.
+  ///
+  /// This request is useful to track which sessions are still alive, and eventually make the daemon quit by itself.
+  SessionEnd,
+
   /// Ask the server/daemon to close and clean up.
   Shutdown,
 


### PR DESCRIPTION
This commit allows sessions to automatically register themselves to `kak-tree-sitter`, so that whenever all sessions have ended, the daemon knows it must quit.