### PR TITLE
Add ktsctl, the CLI controler for kak-tree-sitter.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,6 +283,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ktsctl"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dirs",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
-	"kak-tree-sitter"
+	"kak-tree-sitter",
+	"ktsctl",
 ]

--- a/ktsctl/Cargo.toml
+++ b/ktsctl/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ktsctl"
+version = "0.1.0"
+license = "BSD-3-Clause"
+authors = ["Dimitri Sabadie <dimitri.sabadie@gmail.com>"]
+description = "CLI controler of kak-tree-sitter"
+keywords = []
+categories = []
+homepage = "https://github.com/phaazon/kak-tree-sitter"
+repository = "https://github.com/phaazon/kak-tree-sitter"
+readme = "README.md"
+edition = "2021"
+rust-version = "1.65.0"
+
+[dependencies]
+clap = { version = "4.2.7", features = ["derive"] }
+dirs = "5.0.1"

--- a/ktsctl/src/cli.rs
+++ b/ktsctl/src/cli.rs
@@ -1,0 +1,26 @@
+use clap::Parser;
+
+#[derive(Debug, Parser)]
+pub struct Cli {
+  /// Grammar to fetch.
+  ///
+  /// Grammars are currently fetched from https://github.com/tree-sitter/.
+  #[clap(short, long)]
+  pub grammar: Option<String>,
+
+  /// Whether we should fetch queries.
+  ///
+  /// Queries are currently fetched from https://github.com/helix-editor/helix/.
+  #[clap(short, long)]
+  pub queries: bool,
+
+  /// Whether we should compile fetched grammars.
+  #[clap(short, long)]
+  pub compile: bool,
+
+  /// Whether we should install compiled grammars/queries to the kak-tree-sitter data location.
+  ///
+  /// Implies --compile for grammars.
+  #[clap(short, long)]
+  pub install: bool,
+}

--- a/ktsctl/src/main.rs
+++ b/ktsctl/src/main.rs
@@ -1,0 +1,161 @@
+use std::{
+  env, fs,
+  path::{Path, PathBuf},
+  process::Command,
+};
+
+use clap::Parser;
+use cli::Cli;
+
+mod cli;
+
+fn runtime_dir() -> PathBuf {
+  dirs::runtime_dir()
+    .or_else(|| env::var("TMPDIR").map(PathBuf::from).ok())
+    .unwrap()
+    .join("ktsctl") // FIXME: unwrap()
+}
+
+fn kak_tree_sitter_data_dir() -> PathBuf {
+  dirs::data_dir().unwrap().join("kak-tree-sitter") // FIXME: unwrap()
+}
+
+fn main() {
+  let cli = Cli::parse();
+
+  // check the runtime dir exists
+  let dir = runtime_dir();
+  fs::create_dir_all(&dir).unwrap();
+
+  // check the kak-tree-sitter data dir exists
+  let kak_data_dir = kak_tree_sitter_data_dir();
+  fs::create_dir_all(&kak_data_dir).unwrap();
+
+  if let Some(lang) = cli.grammar {
+    fetch_grammar(&dir, &lang);
+
+    // ensure the build dir exists
+    let lang_build_dir = dir.join(format!("tree-sitter-{lang}/build"));
+    fs::create_dir_all(&lang_build_dir).unwrap(); // FIXME: unwrap()
+
+    if cli.compile {
+      compile(&lang_build_dir, &lang);
+    }
+
+    if cli.install {
+      install_grammar(&lang_build_dir, &lang);
+    }
+  }
+
+  if cli.queries {
+    fetch_queries(&dir);
+
+    if cli.install {
+      let queries_dir = dir.join("helix/runtime/queries");
+      install_queries(&queries_dir);
+    }
+  }
+}
+
+/// Fetch lang’s grammars and queries by targetting https://github.com/tree-sitter/tree-sitter-{lang}.
+fn fetch_grammar(runtime_dir: &Path, lang: &str) {
+  // cleanup / remove the runtime_dir/tree-sitter-{lang} directory, if exists
+  let lang_dir = PathBuf::from(format!(
+    "{runtime_dir}/tree-sitter-{lang}",
+    runtime_dir = runtime_dir.display()
+  ));
+
+  if let Ok(true) = lang_dir.try_exists() {
+    fs::remove_dir_all(lang_dir).unwrap(); // FIXME: unwrap()
+  }
+
+  let url = format!("https://github.com/tree-sitter/tree-sitter-{lang}");
+  Command::new("git")
+    .args(["clone", url.as_str(), "--depth", "1"])
+    .current_dir(runtime_dir)
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap(); // FIXME: unwrap()
+}
+
+/// Compile the grammar.
+fn compile(lang_build_dir: &Path, lang: &str) {
+  // compile into .o
+  Command::new("cc")
+    .args(["-c", "-O3", "../src/scanner.c", "../src/parser.c"])
+    .current_dir(&lang_build_dir)
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap(); // FIXME: unwrap()
+
+  // link into {lang}.so
+  Command::new("cc")
+    .args([
+      "-shared",
+      "-O3",
+      "scanner.o",
+      "parser.o",
+      "-o",
+      format!("{lang}.so").as_str(),
+    ])
+    .current_dir(&lang_build_dir)
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap(); // FIXME: unwrap()
+}
+
+fn install_grammar(lang_build_dir: &Path, lang: &str) {
+  let lang_so = format!("{lang}.so");
+  let source_path = lang_build_dir.join(&lang_so);
+  let grammar_dir = kak_tree_sitter_data_dir().join("grammars");
+  let install_path = grammar_dir.join(lang_so);
+
+  // ensure the grammars directory exists
+  fs::create_dir_all(grammar_dir).unwrap();
+  fs::copy(source_path, install_path).unwrap(); // FIXME: unwrap()
+}
+
+fn fetch_queries(runtime_dir: &Path) {
+  // cleanup / remove the helix directory
+  let hx_dir = PathBuf::from(format!(
+    "{runtime_dir}/helix",
+    runtime_dir = runtime_dir.display()
+  ));
+
+  if let Ok(true) = hx_dir.try_exists() {
+    fs::remove_dir_all(hx_dir).unwrap(); // FIXME: unwrap()
+  }
+
+  let url = format!("https://github.com/helix-editor/helix");
+  Command::new("git")
+    .args(["clone", url.as_str(), "--depth", "1"])
+    .current_dir(runtime_dir)
+    .spawn()
+    .unwrap()
+    .wait()
+    .unwrap(); // FIXME: unwrap()
+}
+
+fn install_queries(query_dir: &Path) {
+  // ensure the queries directory exists
+  let install_path = kak_tree_sitter_data_dir().join("queries");
+  fs::create_dir_all(&install_path).unwrap();
+
+  rec_copy_dir(query_dir, &install_path);
+}
+
+fn rec_copy_dir(from: &Path, to: &Path) {
+  for entry in from.read_dir().unwrap().flatten() {
+    let new_to = to.join(entry.file_name());
+
+    if entry.file_type().unwrap().is_dir() {
+      fs::create_dir_all(&new_to).unwrap();
+      rec_copy_dir(&entry.path(), &new_to);
+    } else {
+      fs::copy(&entry.path(), &new_to).unwrap();
+    }
+  }
+}


### PR DESCRIPTION
It currently only supports fetching, compiling and installing grammars and fetching and installing queries.