### PR TITLE
Fix highlighter range computations

### DIFF
--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -181,14 +181,14 @@ where
   C: Iterator<Item = (usize, char)>,
 {
   fn new(mut chars: C) -> Self {
-    chars.next();
+    let change_line = matches!(chars.next(), Some((_, '\n')));
 
     Self {
       chars,
       byte_idx: 0,
       line: 1,
       col: 1,
-      change_line: false,
+      change_line,
     }
   }
 


### PR DESCRIPTION
Fixes #40.

ByteLineColWrapper was throwing out the first character without checking whether it was a newline. This resulted in generated range lines being offset by -1 for files starting with a line break.