### PR TITLE
Config and custom queries for JS/JSX/TS/TSX

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -488,7 +488,20 @@ pin = "dbd248fdfa680373d94fbc10094a160aafa0f7a7"
 path = "runtime/queries/java"
 
 # javascript
-# TODO
+[language.javascript.grammar]
+url = "https://github.com/tree-sitter/tree-sitter-javascript"
+pin = "f1e5a09b8d02f8209a68249c93f0ad647b228e6e"
+path = "src"
+compile = "cc"
+compile_args = ["-c", "-fpic", "../scanner.c", "../parser.c", "-I", ".."]
+compile_flags = ["-O3"]
+link = "cc"
+link_args = ["-shared", "-fpic", "scanner.o", "parser.o", "-o", "javascript.so"]
+link_flags = ["-O3"]
+
+[language.javascript.queries]
+url = "https://github.com/phaazon/kak-tree-sitter"
+path = "runtime/queries/javascript"
 
 # jsdoc
 # TODO
@@ -514,7 +527,20 @@ path = "runtime/queries/json"
 # TODO
 
 # jsx
-# TODO
+[language.jsx.grammar]
+url = "https://github.com/tree-sitter/tree-sitter-javascript"
+pin = "f1e5a09b8d02f8209a68249c93f0ad647b228e6e"
+path = "src"
+compile = "cc"
+compile_args = ["-c", "-fpic", "../scanner.c", "../parser.c", "-I", ".."]
+compile_flags = ["-O3"]
+link = "cc"
+link_args = ["-shared", "-fpic", "scanner.o", "parser.o", "-o", "jsx.so"]
+link_flags = ["-O3"]
+
+[language.jsx.queries]
+url = "https://github.com/phaazon/kak-tree-sitter"
+path = "runtime/queries/jsx"
 
 # julia
 # TODO
@@ -848,13 +874,39 @@ path = "runtime/queries/toml"
 # TODO
 
 # tsx
-# TODO
+[language.tsx.grammar]
+url = "https://github.com/tree-sitter/tree-sitter-typescript"
+pin = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf"
+path = "tsx/src"
+compile = "cc"
+compile_args = ["-c", "-fpic", "../scanner.c", "../parser.c", "-I", ".."]
+compile_flags = ["-O3"]
+link = "cc"
+link_args = ["-shared", "-fpic", "scanner.o", "parser.o", "-o", "tsx.so"]
+link_flags = ["-O3"]
+
+[language.tsx.queries]
+url = "https://github.com/phaazon/kak-tree-sitter"
+path = "runtime/queries/tsx"
 
 # twig
 # TODO
 
 # typescript
-# TODO
+[language.typescript.grammar]
+url = "https://github.com/tree-sitter/tree-sitter-typescript"
+pin = "b1bf4825d9eaa0f3bdeb1e52f099533328acfbdf"
+path = "typescript/src"
+compile = "cc"
+compile_args = ["-c", "-fpic", "../scanner.c", "../parser.c", "-I", ".."]
+compile_flags = ["-O3"]
+link = "cc"
+link_args = ["-shared", "-fpic", "scanner.o", "parser.o", "-o", "typescript.so"]
+link_flags = ["-O3"]
+
+[language.typescript.queries]
+url = "https://github.com/phaazon/kak-tree-sitter"
+path = "runtime/queries/typescript"
 
 # ungrammar
 # TODO

--- a/runtime/queries/javascript/LICENSE
+++ b/runtime/queries/javascript/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/runtime/queries/javascript/README.md
+++ b/runtime/queries/javascript/README.md
@@ -1,0 +1,3 @@
+All the files in this directory were taken and adapted from
+[Helix Javascript queries](https://github.com/helix-editor/helix/tree/master/runtime/queries/javascript) and are then
+licensed under the [Mozilla Public License 2.0](https://github.com/helix-editor/helix/blob/master/LICENSE).

--- a/runtime/queries/javascript/highlights.scm
+++ b/runtime/queries/javascript/highlights.scm
@@ -1,0 +1,287 @@
+; ecma
+; Special identifiers
+;--------------------
+
+([
+    (identifier)
+    (shorthand_property_identifier)
+    (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+
+
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#eq? @function.builtin "require")
+ (#is-not? local))
+
+; Function and method definitions
+;--------------------------------
+
+(function
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function) (arrow_function)])
+
+; Function and method parameters
+;-------------------------------
+
+; Arrow function parameters in the form `p => ...` are supported by both
+; javascript and typescript grammars without conflicts.
+(arrow_function
+  parameter: (identifier) @variable.parameter)
+  
+; Function and method calls
+;--------------------------
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Variables
+;----------
+
+(identifier) @variable
+
+; Properties
+;-----------
+
+(property_identifier) @variable.other.member
+(shorthand_property_identifier) @variable.other.member
+(shorthand_property_identifier_pattern) @variable.other.member
+
+; Literals
+;---------
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[
+  (true)
+  (false)
+  (null)
+  (undefined)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(regex) @string.regexp
+(number) @constant.numeric.integer
+
+; Tokens
+;-------
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  ";"
+  (optional_chain) ; ?.
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+  "..."
+] @operator
+
+(ternary_expression ["?" ":"] @operator)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  "async"
+  "debugger"
+  "delete"
+  "extends"
+  "from"
+  "get"
+  "new"
+  "set"
+  "target"
+  "typeof"
+  "instanceof"
+  "void"
+  "with"
+] @keyword
+
+[
+  "of"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "function"
+] @keyword.function
+
+[
+  "class"
+  "let"
+  "var"
+] @keyword.storage.type
+
+[
+  "const"
+  "static"
+] @keyword.storage.modifier
+
+[
+  "default"
+  "yield"
+  "finally"
+  "do"
+  "await"
+] @keyword.control
+
+[
+  "if"
+  "else"
+  "switch"
+  "case"
+  "while"
+] @keyword.control.conditional
+
+[
+  "for"
+] @keyword.control.repeat
+
+[
+  "import"
+  "export"
+] @keyword.control.import 
+
+[
+  "return"
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "throw"
+  "try"
+  "catch"
+] @keyword.control.exception
+
+; javascript
+; Function and method parameters
+;-------------------------------
+
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (p)
+(formal_parameters 
+  (identifier) @variable.parameter)
+
+; (...p)
+(formal_parameters
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p })
+(formal_parameters
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p })
+(formal_parameters
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ])
+(formal_parameters
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; (p = 1)
+(formal_parameters
+  (assignment_pattern
+    left: (identifier) @variable.parameter))

--- a/runtime/queries/javascript/indents.scm
+++ b/runtime/queries/javascript/indents.scm
@@ -1,0 +1,31 @@
+; ecma
+[
+  (array)
+  (object)
+  (arguments)
+  (formal_parameters)
+
+  (statement_block)
+  (switch_statement)
+  (object_pattern)
+  (class_body)
+  (named_imports)
+
+  (binary_expression)
+  (return_statement)
+  (template_substitution)
+  (export_clause)
+] @indent
+
+[
+  (switch_case)
+  (switch_default)
+] @indent @extend
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent
+
+; javascript

--- a/runtime/queries/javascript/injections.scm
+++ b/runtime/queries/javascript/injections.scm
@@ -1,0 +1,38 @@
+; ecma
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse the contents of gql template literals
+
+((call_expression
+   function: (identifier) @_template_function_name
+   arguments: (template_string) @injection.content)
+ (#eq? @_template_function_name "gql")
+ (#set! injection.language "graphql"))
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+; Parse JSDoc annotations in multiline comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
+
+; Parse general tags in single line comments
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))
+
+; javascript

--- a/runtime/queries/javascript/locals.scm
+++ b/runtime/queries/javascript/locals.scm
@@ -1,0 +1,60 @@
+; ecma
+; Scopes
+;-------
+
+[
+  (statement_block)
+  (function)
+  (arrow_function)
+  (function_declaration)
+  (method_definition)
+] @local.scope
+
+; Definitions
+;------------
+
+; ...i
+(rest_pattern
+  (identifier) @local.definition)
+
+; { i }
+(object_pattern
+  (shorthand_property_identifier_pattern) @local.definition)
+
+; { a: i }
+(object_pattern
+  (pair_pattern
+    value: (identifier) @local.definition))
+
+; [ i ]
+(array_pattern
+  (identifier) @local.definition)
+
+; i => ...
+(arrow_function
+  parameter: (identifier) @local.definition)
+
+; const/let/var i = ...
+(variable_declarator
+  name: (identifier) @local.definition)
+
+; References
+;------------
+
+(identifier) @local.reference
+
+; javascript
+; Definitions
+;------------
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (i)
+(formal_parameters 
+  (identifier) @local.definition)
+
+; (i = 1)
+(formal_parameters 
+  (assignment_pattern
+    left: (identifier) @local.definition))

--- a/runtime/queries/javascript/tags.scm
+++ b/runtime/queries/javascript/tags.scm
@@ -1,0 +1,91 @@
+; ecma
+
+; javascript
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name) @definition.method
+  (#not-eq? @name "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name)
+    (class_declaration
+      name: (_) @name)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function
+      name: (identifier) @name)
+    (function_declaration
+      name: (identifier) @name)
+    (generator_function
+      name: (identifier) @name)
+    (generator_function_declaration
+      name: (identifier) @name)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name
+    (member_expression
+      property: (property_identifier) @name)
+  ]
+  right: [(arrow_function) (function)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name
+  value: [(arrow_function) (function)]) @definition.function
+
+(
+  (call_expression
+    function: (identifier) @name) @reference.call
+  (#not-match? @name "^(require)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name)
+  arguments: (_) @reference.call)
+
+(new_expression
+  constructor: (_) @name) @reference.class

--- a/runtime/queries/javascript/textobjects.scm
+++ b/runtime/queries/javascript/textobjects.scm
@@ -1,0 +1,39 @@
+; ecma
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(arrow_function
+  body: (_) @function.inside) @function.around
+
+(method_definition
+  body: (_) @function.inside) @function.around
+
+(generator_function_declaration
+  body: (_) @function.inside) @function.around
+
+(class_declaration
+  body: (class_body) @class.inside) @class.around
+
+(class
+  (class_body) @class.inside) @class.around
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.around
+    (class_declaration) @class.around 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+; javascript

--- a/runtime/queries/jsx/LICENSE
+++ b/runtime/queries/jsx/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/runtime/queries/jsx/README.md
+++ b/runtime/queries/jsx/README.md
@@ -1,0 +1,3 @@
+All the files in this directory were taken and adapted from
+[Helix JSX queries](https://github.com/helix-editor/helix/tree/master/runtime/queries/jsx) and are then
+licensed under the [Mozilla Public License 2.0](https://github.com/helix-editor/helix/blob/master/LICENSE).

--- a/runtime/queries/jsx/highlights.scm
+++ b/runtime/queries/jsx/highlights.scm
@@ -1,0 +1,332 @@
+; ecma
+; Special identifiers
+;--------------------
+
+([
+    (identifier)
+    (shorthand_property_identifier)
+    (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+
+
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#eq? @function.builtin "require")
+ (#is-not? local))
+
+; Function and method definitions
+;--------------------------------
+
+(function
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function) (arrow_function)])
+
+; Function and method parameters
+;-------------------------------
+
+; Arrow function parameters in the form `p => ...` are supported by both
+; javascript and typescript grammars without conflicts.
+(arrow_function
+  parameter: (identifier) @variable.parameter)
+  
+; Function and method calls
+;--------------------------
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Variables
+;----------
+
+(identifier) @variable
+
+; Properties
+;-----------
+
+(property_identifier) @variable.other.member
+(shorthand_property_identifier) @variable.other.member
+(shorthand_property_identifier_pattern) @variable.other.member
+
+; Literals
+;---------
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[
+  (true)
+  (false)
+  (null)
+  (undefined)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(regex) @string.regexp
+(number) @constant.numeric.integer
+
+; Tokens
+;-------
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  ";"
+  (optional_chain) ; ?.
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+  "..."
+] @operator
+
+(ternary_expression ["?" ":"] @operator)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  "async"
+  "debugger"
+  "delete"
+  "extends"
+  "from"
+  "get"
+  "new"
+  "set"
+  "target"
+  "typeof"
+  "instanceof"
+  "void"
+  "with"
+] @keyword
+
+[
+  "of"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "function"
+] @keyword.function
+
+[
+  "class"
+  "let"
+  "var"
+] @keyword.storage.type
+
+[
+  "const"
+  "static"
+] @keyword.storage.modifier
+
+[
+  "default"
+  "yield"
+  "finally"
+  "do"
+  "await"
+] @keyword.control
+
+[
+  "if"
+  "else"
+  "switch"
+  "case"
+  "while"
+] @keyword.control.conditional
+
+[
+  "for"
+] @keyword.control.repeat
+
+[
+  "import"
+  "export"
+] @keyword.control.import 
+
+[
+  "return"
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "throw"
+  "try"
+  "catch"
+] @keyword.control.exception
+
+; jsx
+; Opening elements
+; ----------------
+
+(jsx_opening_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_opening_element (identifier) @tag)
+
+; Closing elements
+; ----------------
+
+(jsx_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_closing_element (identifier) @tag)
+
+; Self-closing elements
+; ---------------------
+
+(jsx_self_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_self_closing_element (identifier) @tag)
+
+; Attributes
+; ----------
+
+(jsx_attribute (property_identifier) @variable.other.member)
+
+; Punctuation
+; -----------
+
+; Handle attribute delimiter (<Component color="red"/>)
+(jsx_attribute "=" @punctuation.delimiter)
+
+; <Component>
+(jsx_opening_element ["<" ">"] @punctuation.bracket)
+
+; </Component>
+(jsx_closing_element ["</" ">"] @punctuation.bracket)
+
+; <Component />
+(jsx_self_closing_element ["<" "/>"] @punctuation.braket)
+
+; javascript
+; Function and method parameters
+;-------------------------------
+
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (p)
+(formal_parameters 
+  (identifier) @variable.parameter)
+
+; (...p)
+(formal_parameters
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p })
+(formal_parameters
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p })
+(formal_parameters
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ])
+(formal_parameters
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; (p = 1)
+(formal_parameters
+  (assignment_pattern
+    left: (identifier) @variable.parameter))

--- a/runtime/queries/jsx/indents.scm
+++ b/runtime/queries/jsx/indents.scm
@@ -1,0 +1,39 @@
+; ecma
+[
+  (array)
+  (object)
+  (arguments)
+  (formal_parameters)
+
+  (statement_block)
+  (switch_statement)
+  (object_pattern)
+  (class_body)
+  (named_imports)
+
+  (binary_expression)
+  (return_statement)
+  (template_substitution)
+  (export_clause)
+] @indent
+
+[
+  (switch_case)
+  (switch_default)
+] @indent @extend
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent
+
+; jsx
+[
+  (jsx_element)
+  (jsx_self_closing_element)
+] @indent
+
+(parenthesized_expression) @indent
+
+; javascript

--- a/runtime/queries/jsx/injections.scm
+++ b/runtime/queries/jsx/injections.scm
@@ -1,0 +1,40 @@
+; ecma
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse the contents of gql template literals
+
+((call_expression
+   function: (identifier) @_template_function_name
+   arguments: (template_string) @injection.content)
+ (#eq? @_template_function_name "gql")
+ (#set! injection.language "graphql"))
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+; Parse JSDoc annotations in multiline comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
+
+; Parse general tags in single line comments
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))
+
+; jsx
+
+; javascript

--- a/runtime/queries/jsx/locals.scm
+++ b/runtime/queries/jsx/locals.scm
@@ -1,0 +1,62 @@
+; ecma
+; Scopes
+;-------
+
+[
+  (statement_block)
+  (function)
+  (arrow_function)
+  (function_declaration)
+  (method_definition)
+] @local.scope
+
+; Definitions
+;------------
+
+; ...i
+(rest_pattern
+  (identifier) @local.definition)
+
+; { i }
+(object_pattern
+  (shorthand_property_identifier_pattern) @local.definition)
+
+; { a: i }
+(object_pattern
+  (pair_pattern
+    value: (identifier) @local.definition))
+
+; [ i ]
+(array_pattern
+  (identifier) @local.definition)
+
+; i => ...
+(arrow_function
+  parameter: (identifier) @local.definition)
+
+; const/let/var i = ...
+(variable_declarator
+  name: (identifier) @local.definition)
+
+; References
+;------------
+
+(identifier) @local.reference
+
+; jsx
+
+; javascript
+; Definitions
+;------------
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (i)
+(formal_parameters 
+  (identifier) @local.definition)
+
+; (i = 1)
+(formal_parameters 
+  (assignment_pattern
+    left: (identifier) @local.definition))

--- a/runtime/queries/jsx/tags.scm
+++ b/runtime/queries/jsx/tags.scm
@@ -1,0 +1,93 @@
+; ecma
+
+; jsx
+
+; javascript
+(
+  (comment)* @doc
+  .
+  (method_definition
+    name: (property_identifier) @name) @definition.method
+  (#not-eq? @name "constructor")
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.method)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (class
+      name: (_) @name)
+    (class_declaration
+      name: (_) @name)
+  ] @definition.class
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.class)
+)
+
+(
+  (comment)* @doc
+  .
+  [
+    (function
+      name: (identifier) @name)
+    (function_declaration
+      name: (identifier) @name)
+    (generator_function
+      name: (identifier) @name)
+    (generator_function_declaration
+      name: (identifier) @name)
+  ] @definition.function
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (lexical_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(
+  (comment)* @doc
+  .
+  (variable_declaration
+    (variable_declarator
+      name: (identifier) @name
+      value: [(arrow_function) (function)]) @definition.function)
+  (#strip! @doc "^[\\s\\*/]+|^[\\s\\*/]$")
+  (#select-adjacent! @doc @definition.function)
+)
+
+(assignment_expression
+  left: [
+    (identifier) @name
+    (member_expression
+      property: (property_identifier) @name)
+  ]
+  right: [(arrow_function) (function)]
+) @definition.function
+
+(pair
+  key: (property_identifier) @name
+  value: [(arrow_function) (function)]) @definition.function
+
+(
+  (call_expression
+    function: (identifier) @name) @reference.call
+  (#not-match? @name "^(require)$")
+)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @name)
+  arguments: (_) @reference.call)
+
+(new_expression
+  constructor: (_) @name) @reference.class

--- a/runtime/queries/jsx/textobjects.scm
+++ b/runtime/queries/jsx/textobjects.scm
@@ -1,0 +1,41 @@
+; ecma
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(arrow_function
+  body: (_) @function.inside) @function.around
+
+(method_definition
+  body: (_) @function.inside) @function.around
+
+(generator_function_declaration
+  body: (_) @function.inside) @function.around
+
+(class_declaration
+  body: (class_body) @class.inside) @class.around
+
+(class
+  (class_body) @class.inside) @class.around
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.around
+    (class_declaration) @class.around 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+; jsx
+
+; javascript

--- a/runtime/queries/tsx/LICENSE
+++ b/runtime/queries/tsx/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/runtime/queries/tsx/README.md
+++ b/runtime/queries/tsx/README.md
@@ -1,0 +1,3 @@
+All the files in this directory were taken and adapted from
+[Helix TSX queries](https://github.com/helix-editor/helix/tree/master/runtime/queries/tsx) and are then
+licensed under the [Mozilla Public License 2.0](https://github.com/helix-editor/helix/blob/master/LICENSE).

--- a/runtime/queries/tsx/highlights.scm
+++ b/runtime/queries/tsx/highlights.scm
@@ -1,0 +1,436 @@
+; ecma
+; Special identifiers
+;--------------------
+
+([
+    (identifier)
+    (shorthand_property_identifier)
+    (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+
+
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#eq? @function.builtin "require")
+ (#is-not? local))
+
+; Function and method definitions
+;--------------------------------
+
+(function
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function) (arrow_function)])
+
+; Function and method parameters
+;-------------------------------
+
+; Arrow function parameters in the form `p => ...` are supported by both
+; javascript and typescript grammars without conflicts.
+(arrow_function
+  parameter: (identifier) @variable.parameter)
+  
+; Function and method calls
+;--------------------------
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Variables
+;----------
+
+(identifier) @variable
+
+; Properties
+;-----------
+
+(property_identifier) @variable.other.member
+(shorthand_property_identifier) @variable.other.member
+(shorthand_property_identifier_pattern) @variable.other.member
+
+; Literals
+;---------
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[
+  (true)
+  (false)
+  (null)
+  (undefined)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(regex) @string.regexp
+(number) @constant.numeric.integer
+
+; Tokens
+;-------
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  ";"
+  (optional_chain) ; ?.
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+  "..."
+] @operator
+
+(ternary_expression ["?" ":"] @operator)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  "async"
+  "debugger"
+  "delete"
+  "extends"
+  "from"
+  "get"
+  "new"
+  "set"
+  "target"
+  "typeof"
+  "instanceof"
+  "void"
+  "with"
+] @keyword
+
+[
+  "of"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "function"
+] @keyword.function
+
+[
+  "class"
+  "let"
+  "var"
+] @keyword.storage.type
+
+[
+  "const"
+  "static"
+] @keyword.storage.modifier
+
+[
+  "default"
+  "yield"
+  "finally"
+  "do"
+  "await"
+] @keyword.control
+
+[
+  "if"
+  "else"
+  "switch"
+  "case"
+  "while"
+] @keyword.control.conditional
+
+[
+  "for"
+] @keyword.control.repeat
+
+[
+  "import"
+  "export"
+] @keyword.control.import 
+
+[
+  "return"
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "throw"
+  "try"
+  "catch"
+] @keyword.control.exception
+
+; jsx
+; Opening elements
+; ----------------
+
+(jsx_opening_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_opening_element (identifier) @tag)
+
+; Closing elements
+; ----------------
+
+(jsx_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_closing_element (identifier) @tag)
+
+; Self-closing elements
+; ---------------------
+
+(jsx_self_closing_element ((identifier) @constructor
+ (#match? @constructor "^[A-Z]")))
+
+(jsx_self_closing_element (identifier) @tag)
+
+; Attributes
+; ----------
+
+(jsx_attribute (property_identifier) @variable.other.member)
+
+; Punctuation
+; -----------
+
+; Handle attribute delimiter (<Component color="red"/>)
+(jsx_attribute "=" @punctuation.delimiter)
+
+; <Component>
+(jsx_opening_element ["<" ">"] @punctuation.bracket)
+
+; </Component>
+(jsx_closing_element ["</" ">"] @punctuation.bracket)
+
+; <Component />
+(jsx_self_closing_element ["<" "/>"] @punctuation.braket)
+
+; typescript
+; Namespaces
+; ----------
+
+(internal_module
+  [((identifier) @namespace) ((nested_identifier (identifier) @namespace))])
+
+(ambient_declaration "global" @namespace)
+
+; Parameters
+; ----------
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (p: t)
+; (p: t = 1)
+(required_parameter 
+  (identifier) @variable.parameter)
+
+; (...p: t)
+(required_parameter
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p }: { p: t })
+(required_parameter
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p }: { a: t })
+(required_parameter
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ]: t[])
+(required_parameter
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; (p?: t)
+; (p?: t = 1) // Invalid but still posible to hihglight.
+(optional_parameter 
+  (identifier) @variable.parameter)
+
+; (...p?: t) // Invalid but still posible to hihglight.
+(optional_parameter
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p }: { p?: t})
+(optional_parameter
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p }: { a?: t })
+(optional_parameter
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ]?: t[]) // Invalid but still posible to hihglight.
+(optional_parameter
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; Punctuation
+; -----------
+
+[
+  ":"
+] @punctuation.delimiter
+
+(optional_parameter "?" @punctuation.special)
+(property_signature "?" @punctuation.special)
+
+(conditional_type ["?" ":"] @operator)
+
+; Keywords
+; --------
+
+[
+  "abstract"
+  "declare"
+  "export"
+  "infer"
+  "implements"
+  "keyof"
+  "namespace"
+  "override"
+  "satisfies"
+] @keyword
+
+[
+  "type"
+  "interface"
+  "enum"
+] @keyword.storage.type
+
+[
+  "public"
+  "private"
+  "protected"
+  "readonly"
+] @keyword.storage.modifier
+
+; Types
+; -----
+
+(type_identifier) @type
+(predefined_type) @type.builtin
+
+; Type arguments and parameters
+; -----------------------------
+
+(type_arguments
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(type_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+; Literals
+; --------
+
+[
+  (template_literal_type)
+] @string
+
+; Tokens
+; ------
+
+(template_type
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded

--- a/runtime/queries/tsx/indents.scm
+++ b/runtime/queries/tsx/indents.scm
@@ -1,0 +1,44 @@
+; ecma
+[
+  (array)
+  (object)
+  (arguments)
+  (formal_parameters)
+
+  (statement_block)
+  (switch_statement)
+  (object_pattern)
+  (class_body)
+  (named_imports)
+
+  (binary_expression)
+  (return_statement)
+  (template_substitution)
+  (export_clause)
+] @indent
+
+[
+  (switch_case)
+  (switch_default)
+] @indent @extend
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent
+
+; jsx
+[
+  (jsx_element)
+  (jsx_self_closing_element)
+] @indent
+
+(parenthesized_expression) @indent
+
+; typescript
+[
+  (enum_declaration) 
+  (interface_declaration)
+  (object_type)
+] @indent

--- a/runtime/queries/tsx/injections.scm
+++ b/runtime/queries/tsx/injections.scm
@@ -1,0 +1,40 @@
+; ecma
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse the contents of gql template literals
+
+((call_expression
+   function: (identifier) @_template_function_name
+   arguments: (template_string) @injection.content)
+ (#eq? @_template_function_name "gql")
+ (#set! injection.language "graphql"))
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+; Parse JSDoc annotations in multiline comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
+
+; Parse general tags in single line comments
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))
+
+; jsx
+
+; typescript

--- a/runtime/queries/tsx/locals.scm
+++ b/runtime/queries/tsx/locals.scm
@@ -1,0 +1,64 @@
+; ecma
+; Scopes
+;-------
+
+[
+  (statement_block)
+  (function)
+  (arrow_function)
+  (function_declaration)
+  (method_definition)
+] @local.scope
+
+; Definitions
+;------------
+
+; ...i
+(rest_pattern
+  (identifier) @local.definition)
+
+; { i }
+(object_pattern
+  (shorthand_property_identifier_pattern) @local.definition)
+
+; { a: i }
+(object_pattern
+  (pair_pattern
+    value: (identifier) @local.definition))
+
+; [ i ]
+(array_pattern
+  (identifier) @local.definition)
+
+; i => ...
+(arrow_function
+  parameter: (identifier) @local.definition)
+
+; const/let/var i = ...
+(variable_declarator
+  name: (identifier) @local.definition)
+
+; References
+;------------
+
+(identifier) @local.reference
+
+; jsx
+
+; typescript
+; Definitions
+;------------
+
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (i: t)
+; (i: t = 1)
+(required_parameter
+  (identifier) @local.definition)
+
+; (i?: t)
+; (i?: t = 1) // Invalid but still posible to hihglight.
+(optional_parameter
+  (identifier) @local.definition)

--- a/runtime/queries/tsx/tags.scm
+++ b/runtime/queries/tsx/tags.scm
@@ -1,0 +1,21 @@
+; ecma
+
+; jsx
+
+; typescript
+; Definitions
+;------------
+
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (i: t)
+; (i: t = 1)
+(required_parameter
+  (identifier) @local.definition)
+
+; (i?: t)
+; (i?: t = 1) // Invalid but still posible to hihglight.
+(optional_parameter
+  (identifier) @local.definition)

--- a/runtime/queries/tsx/textobjects.scm
+++ b/runtime/queries/tsx/textobjects.scm
@@ -1,0 +1,47 @@
+; ecma
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(arrow_function
+  body: (_) @function.inside) @function.around
+
+(method_definition
+  body: (_) @function.inside) @function.around
+
+(generator_function_declaration
+  body: (_) @function.inside) @function.around
+
+(class_declaration
+  body: (class_body) @class.inside) @class.around
+
+(class
+  (class_body) @class.inside) @class.around
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.around
+    (class_declaration) @class.around 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+; jsx
+
+; typescript
+[
+  (interface_declaration 
+    body:(_) @class.inside)
+  (type_alias_declaration 
+    value: (_) @class.inside)
+] @class.around

--- a/runtime/queries/typescript/LICENSE
+++ b/runtime/queries/typescript/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/runtime/queries/typescript/README.md
+++ b/runtime/queries/typescript/README.md
@@ -1,0 +1,3 @@
+All the files in this directory were taken and adapted from
+[Helix Typescript queries](https://github.com/helix-editor/helix/tree/master/runtime/queries/typescript) and are then
+licensed under the [Mozilla Public License 2.0](https://github.com/helix-editor/helix/blob/master/LICENSE).

--- a/runtime/queries/typescript/highlights.scm
+++ b/runtime/queries/typescript/highlights.scm
@@ -1,0 +1,391 @@
+; ecma
+; Special identifiers
+;--------------------
+
+([
+    (identifier)
+    (shorthand_property_identifier)
+    (shorthand_property_identifier_pattern)
+ ] @constant
+ (#match? @constant "^[A-Z_][A-Z\\d_]+$"))
+
+
+((identifier) @constructor
+ (#match? @constructor "^[A-Z]"))
+
+((identifier) @variable.builtin
+ (#match? @variable.builtin "^(arguments|module|console|window|document)$")
+ (#is-not? local))
+
+((identifier) @function.builtin
+ (#eq? @function.builtin "require")
+ (#is-not? local))
+
+; Function and method definitions
+;--------------------------------
+
+(function
+  name: (identifier) @function)
+(function_declaration
+  name: (identifier) @function)
+(method_definition
+  name: (property_identifier) @function.method)
+
+(pair
+  key: (property_identifier) @function.method
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (member_expression
+    property: (property_identifier) @function.method)
+  right: [(function) (arrow_function)])
+
+(variable_declarator
+  name: (identifier) @function
+  value: [(function) (arrow_function)])
+
+(assignment_expression
+  left: (identifier) @function
+  right: [(function) (arrow_function)])
+
+; Function and method parameters
+;-------------------------------
+
+; Arrow function parameters in the form `p => ...` are supported by both
+; javascript and typescript grammars without conflicts.
+(arrow_function
+  parameter: (identifier) @variable.parameter)
+  
+; Function and method calls
+;--------------------------
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (member_expression
+    property: (property_identifier) @function.method))
+
+; Variables
+;----------
+
+(identifier) @variable
+
+; Properties
+;-----------
+
+(property_identifier) @variable.other.member
+(shorthand_property_identifier) @variable.other.member
+(shorthand_property_identifier_pattern) @variable.other.member
+
+; Literals
+;---------
+
+(this) @variable.builtin
+(super) @variable.builtin
+
+[
+  (true)
+  (false)
+  (null)
+  (undefined)
+] @constant.builtin
+
+(comment) @comment
+
+[
+  (string)
+  (template_string)
+] @string
+
+(regex) @string.regexp
+(number) @constant.numeric.integer
+
+; Tokens
+;-------
+
+(template_substitution
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+[
+  ";"
+  (optional_chain) ; ?.
+  "."
+  ","
+] @punctuation.delimiter
+
+[
+  "-"
+  "--"
+  "-="
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "**"
+  "**="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<"
+  "<="
+  "<<"
+  "<<="
+  "="
+  "=="
+  "==="
+  "!"
+  "!="
+  "!=="
+  "=>"
+  ">"
+  ">="
+  ">>"
+  ">>="
+  ">>>"
+  ">>>="
+  "~"
+  "^"
+  "&"
+  "|"
+  "^="
+  "&="
+  "|="
+  "&&"
+  "||"
+  "??"
+  "&&="
+  "||="
+  "??="
+  "..."
+] @operator
+
+(ternary_expression ["?" ":"] @operator)
+
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+]  @punctuation.bracket
+
+[
+  "async"
+  "debugger"
+  "delete"
+  "extends"
+  "from"
+  "get"
+  "new"
+  "set"
+  "target"
+  "typeof"
+  "instanceof"
+  "void"
+  "with"
+] @keyword
+
+[
+  "of"
+  "as"
+  "in"
+] @keyword.operator
+
+[
+  "function"
+] @keyword.function
+
+[
+  "class"
+  "let"
+  "var"
+] @keyword.storage.type
+
+[
+  "const"
+  "static"
+] @keyword.storage.modifier
+
+[
+  "default"
+  "yield"
+  "finally"
+  "do"
+  "await"
+] @keyword.control
+
+[
+  "if"
+  "else"
+  "switch"
+  "case"
+  "while"
+] @keyword.control.conditional
+
+[
+  "for"
+] @keyword.control.repeat
+
+[
+  "import"
+  "export"
+] @keyword.control.import 
+
+[
+  "return"
+  "break"
+  "continue"
+] @keyword.control.return
+
+[
+  "throw"
+  "try"
+  "catch"
+] @keyword.control.exception
+
+; typescript
+; Namespaces
+; ----------
+
+(internal_module
+  [((identifier) @namespace) ((nested_identifier (identifier) @namespace))])
+
+(ambient_declaration "global" @namespace)
+
+; Parameters
+; ----------
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (p: t)
+; (p: t = 1)
+(required_parameter 
+  (identifier) @variable.parameter)
+
+; (...p: t)
+(required_parameter
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p }: { p: t })
+(required_parameter
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p }: { a: t })
+(required_parameter
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ]: t[])
+(required_parameter
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; (p?: t)
+; (p?: t = 1) // Invalid but still posible to hihglight.
+(optional_parameter 
+  (identifier) @variable.parameter)
+
+; (...p?: t) // Invalid but still posible to hihglight.
+(optional_parameter
+  (rest_pattern
+    (identifier) @variable.parameter))
+
+; ({ p }: { p?: t})
+(optional_parameter
+  (object_pattern
+    (shorthand_property_identifier_pattern) @variable.parameter))
+
+; ({ a: p }: { a?: t })
+(optional_parameter
+  (object_pattern
+    (pair_pattern
+      value: (identifier) @variable.parameter)))
+
+; ([ p ]?: t[]) // Invalid but still posible to hihglight.
+(optional_parameter
+  (array_pattern
+    (identifier) @variable.parameter))
+
+; Punctuation
+; -----------
+
+[
+  ":"
+] @punctuation.delimiter
+
+(optional_parameter "?" @punctuation.special)
+(property_signature "?" @punctuation.special)
+
+(conditional_type ["?" ":"] @operator)
+
+; Keywords
+; --------
+
+[
+  "abstract"
+  "declare"
+  "export"
+  "infer"
+  "implements"
+  "keyof"
+  "namespace"
+  "override"
+  "satisfies"
+] @keyword
+
+[
+  "type"
+  "interface"
+  "enum"
+] @keyword.storage.type
+
+[
+  "public"
+  "private"
+  "protected"
+  "readonly"
+] @keyword.storage.modifier
+
+; Types
+; -----
+
+(type_identifier) @type
+(predefined_type) @type.builtin
+
+; Type arguments and parameters
+; -----------------------------
+
+(type_arguments
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+(type_parameters
+  [
+    "<"
+    ">"
+  ] @punctuation.bracket)
+
+; Literals
+; --------
+
+[
+  (template_literal_type)
+] @string
+
+; Tokens
+; ------
+
+(template_type
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded

--- a/runtime/queries/typescript/indents.scm
+++ b/runtime/queries/typescript/indents.scm
@@ -1,0 +1,66 @@
+; ecma
+[
+  (array)
+  (object)
+  (arguments)
+  (formal_parameters)
+
+  (statement_block)
+  (switch_statement)
+  (object_pattern)
+  (class_body)
+  (named_imports)
+
+  (binary_expression)
+  (return_statement)
+  (template_substitution)
+  (export_clause)
+] @indent
+
+[
+  (switch_case)
+  (switch_default)
+] @indent @extend
+
+[
+  "}"
+  "]"
+  ")"
+] @outdent
+
+; typescript
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse the contents of gql template literals
+
+((call_expression
+   function: (identifier) @_template_function_name
+   arguments: (template_string) @injection.content)
+ (#eq? @_template_function_name "gql")
+ (#set! injection.language "graphql"))
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+; Parse JSDoc annotations in multiline comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
+
+; Parse general tags in single line comments
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))

--- a/runtime/queries/typescript/injections.scm
+++ b/runtime/queries/typescript/injections.scm
@@ -1,0 +1,38 @@
+; ecma
+; Parse the contents of tagged template literals using
+; a language inferred from the tag.
+
+(call_expression
+  function: [
+    (identifier) @injection.language
+    (member_expression
+      property: (property_identifier) @injection.language)
+  ]
+  arguments: (template_string) @injection.content)
+
+; Parse the contents of gql template literals
+
+((call_expression
+   function: (identifier) @_template_function_name
+   arguments: (template_string) @injection.content)
+ (#eq? @_template_function_name "gql")
+ (#set! injection.language "graphql"))
+
+; Parse regex syntax within regex literals
+
+((regex_pattern) @injection.content
+ (#set! injection.language "regex"))
+
+; Parse JSDoc annotations in multiline comments
+
+((comment) @injection.content
+ (#set! injection.language "jsdoc")
+ (#match? @injection.content "^/\\*+"))
+
+; Parse general tags in single line comments
+
+((comment) @injection.content
+ (#set! injection.language "comment")
+ (#match? @injection.content "^//"))
+
+; typescript

--- a/runtime/queries/typescript/locals.scm
+++ b/runtime/queries/typescript/locals.scm
@@ -1,0 +1,62 @@
+; ecma
+; Scopes
+;-------
+
+[
+  (statement_block)
+  (function)
+  (arrow_function)
+  (function_declaration)
+  (method_definition)
+] @local.scope
+
+; Definitions
+;------------
+
+; ...i
+(rest_pattern
+  (identifier) @local.definition)
+
+; { i }
+(object_pattern
+  (shorthand_property_identifier_pattern) @local.definition)
+
+; { a: i }
+(object_pattern
+  (pair_pattern
+    value: (identifier) @local.definition))
+
+; [ i ]
+(array_pattern
+  (identifier) @local.definition)
+
+; i => ...
+(arrow_function
+  parameter: (identifier) @local.definition)
+
+; const/let/var i = ...
+(variable_declarator
+  name: (identifier) @local.definition)
+
+; References
+;------------
+
+(identifier) @local.reference
+
+; typescript
+; Definitions
+;------------
+
+; Javascript and Typescript Treesitter grammars deviate when defining the
+; tree structure for parameters, so we need to address them in each specific
+; language instead of ecma.
+
+; (i: t)
+; (i: t = 1)
+(required_parameter
+  (identifier) @local.definition)
+
+; (i?: t)
+; (i?: t = 1) // Invalid but still posible to hihglight.
+(optional_parameter
+  (identifier) @local.definition)

--- a/runtime/queries/typescript/tags.scm
+++ b/runtime/queries/typescript/tags.scm
@@ -1,0 +1,39 @@
+; ecma
+
+; typescript
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(arrow_function
+  body: (_) @function.inside) @function.around
+
+(method_definition
+  body: (_) @function.inside) @function.around
+
+(generator_function_declaration
+  body: (_) @function.inside) @function.around
+
+(class_declaration
+  body: (class_body) @class.inside) @class.around
+
+(class
+  (class_body) @class.inside) @class.around
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.around
+    (class_declaration) @class.around 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around

--- a/runtime/queries/typescript/textobjects.scm
+++ b/runtime/queries/typescript/textobjects.scm
@@ -1,0 +1,45 @@
+; ecma
+(function_declaration
+  body: (_) @function.inside) @function.around
+
+(function
+  body: (_) @function.inside) @function.around
+
+(arrow_function
+  body: (_) @function.inside) @function.around
+
+(method_definition
+  body: (_) @function.inside) @function.around
+
+(generator_function_declaration
+  body: (_) @function.inside) @function.around
+
+(class_declaration
+  body: (class_body) @class.inside) @class.around
+
+(class
+  (class_body) @class.inside) @class.around
+
+(export_statement
+  declaration: [
+    (function_declaration) @function.around
+    (class_declaration) @class.around 
+  ])
+
+(formal_parameters
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(arguments
+  ((_) @parameter.inside . ","? @parameter.around) @parameter.around)
+
+(comment) @comment.inside
+
+(comment)+ @comment.around
+
+; typescript
+[
+  (interface_declaration 
+    body:(_) @class.inside)
+  (type_alias_declaration 
+    value: (_) @class.inside)
+] @class.around


### PR DESCRIPTION
I've taken queries from `helix` main, processed and tested them a bit on JS/JSX/TS/TSX files. All seems good:

<img width="1142" alt="Screenshot 2023-09-03 at 12 11 48 PM" src="https://github.com/phaazon/kak-tree-sitter/assets/108860307/a08abe96-0733-4c5c-a2e1-8b5a6c99f9f7">

But I have some questions:

- [x] is `</` part of `</div>` or any other closing tag highlighted grey because of semantic highlighting or I did something wrong?
- [x] how can I add the license, should I use other `kak-tree-sitter` bundled queries as an example or you'll do it yourself?
- there is a caveat when using `javascript` parser for `kts_lang == jsx`: https://github.com/tree-sitter/tree-sitter-javascript/issues/244
  - `tree-sitter-javascript` is written for `javascript` languageId
  - so you need to modify source files on `-c` stage of `ktsctl -fci jsx` run
  - I've come up with a simple shell command to replace all `javacscript` mentions in parser code: `grep -rl 'javascript' . | xargs sed -i '' -e 's/javascript/jsx/g'`
    - [ ] this is a manual and pretty dirty hack, but it is what it is - is it ok for now or you do have any other ideas? I couldn't inject this command right to `language.jsx.grammar.compile` because [piping](https://doc.rust-lang.org/std/process/struct.Command.html) mechanisms of rust will require editing `ktsctl` sources
  - if you did prepared your sources for `jsx`, everything will work and `jsx` language will be recognized
  - info: `tsx` does not have such problems because of split `tsx` and `typescript` parsers in their repo

Queries are merged according to doc: https://github.com/helix-editor/helix/tree/master/runtime/queries/ecma#inheritance-model-for-ecma-based-languages