### PR TITLE
Fix FIFO corrupted data.

### DIFF
--- a/kak-tree-sitter/build.rs
+++ b/kak-tree-sitter/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+  let output = Command::new("git")
+    .args(["rev-parse", "--short", "HEAD"])
+    .output()
+    .unwrap();
+
+  let key = "GIT_HEAD";
+  let value = String::from_utf8(output.stdout).unwrap();
+  println!("cargo:rustc-env={key}={value}");
+}

--- a/kak-tree-sitter/src/cli.rs
+++ b/kak-tree-sitter/src/cli.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 #[clap(
   author = "Dimitri Sabadie <dimitri.sabadie@gmail.com>",
   name = "kak-tree-sitter",
-  version,
+  version = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_HEAD")),
   about = "A client/server interface between Kakoune and tree-sitter."
 )]
 pub struct Cli {

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -601,13 +601,14 @@ impl FifoHandler {
       session_name = session.name()
     );
 
-    match file.read_to_string(buffer) {
-      Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
-        log::warn!("command FIFO is not ready");
+    if let Err(err) = file.read_to_string(buffer) {
+      if err.kind() == io::ErrorKind::WouldBlock {
+        log::debug!("command FIFO is not ready");
         return Ok(());
+      } else {
+        buffer.clear();
+        return Err(err.into());
       }
-
-      x => x?,
     };
 
     log::info!("FIFO request: {buffer}");
@@ -685,13 +686,13 @@ impl FifoHandler {
       session_name = session.name()
     );
 
-    match file.read_to_string(buffer) {
-      Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
-        log::warn!("buffer FIFO is not ready");
+    if let Err(err) = file.read_to_string(buffer) {
+      if err.kind() == io::ErrorKind::WouldBlock {
+        log::debug!("buffer FIFO is not ready");
         return Ok(());
+      } else {
+        return Err(err.into());
       }
-
-      x => x?,
     };
 
     let res = self.process_buf(session, buffer);

--- a/ktsctl/build.rs
+++ b/ktsctl/build.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+fn main() {
+  let output = Command::new("git")
+    .args(["rev-parse", "--short", "HEAD"])
+    .output()
+    .unwrap();
+
+  let key = "GIT_HEAD";
+  let value = String::from_utf8(output.stdout).unwrap();
+  println!("cargo:rustc-env={key}={value}");
+}

--- a/ktsctl/src/cli.rs
+++ b/ktsctl/src/cli.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 #[clap(
   author = "Dimitri Sabadie <dimitri.sabadie@gmail.com>",
   name = "ktsctl",
-  version,
+  version = concat!(env!("CARGO_PKG_VERSION"), "-", env!("GIT_HEAD")),
   about = "CLI controler of kak-tree-sitter"
 )]
 pub struct Cli {


### PR DESCRIPTION
That was probably due to the fact we caught FIFO errors where kind() != WouldBlock, but didn’t clear the buffer. The next command would then be appended to the rest and that would lead to non UTF-8 / bad command buffers.