### PR TITLE
Add Julia support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -557,7 +557,7 @@ link_flags = ["-O3"]
 [language.julia.queries]
 url = "https://github.com/helix-editor/helix"
 pin = "dbd248fdfa680373d94fbc10094a160aafa0f7a7"
-path = "runtime/queries/json"
+path = "runtime/queries/julia"
 
 # just
 # TODO

--- a/config.toml
+++ b/config.toml
@@ -543,7 +543,21 @@ url = "https://github.com/phaazon/kak-tree-sitter"
 path = "runtime/queries/jsx"
 
 # julia
-# TODO
+[language.julia.grammar]
+url = "https://github.com/tree-sitter/tree-sitter-julia"
+pin = "0c088d1ad270f02c4e84189247ac7001e86fe342"
+path = "src"
+compile = "cc"
+compile_args = ["-c", "-fpic", "../parser.c", "-I", ".."]
+compile_flags = ["-O3"]
+link = "cc"
+link_args = ["-shared", "-fpic", "parser.o", "-o", "julia.so"]
+link_flags = ["-O3"]
+
+[language.julia.queries]
+url = "https://github.com/helix-editor/helix"
+pin = "dbd248fdfa680373d94fbc10094a160aafa0f7a7"
+path = "runtime/queries/json"
 
 # just
 # TODO

--- a/config.toml
+++ b/config.toml
@@ -545,13 +545,13 @@ path = "runtime/queries/jsx"
 # julia
 [language.julia.grammar]
 url = "https://github.com/tree-sitter/tree-sitter-julia"
-pin = "0c088d1ad270f02c4e84189247ac7001e86fe342"
+pin = "2f885efd38a6a6abfefc81d53ecdd99812dcde69"
 path = "src"
 compile = "cc"
-compile_args = ["-c", "-fpic", "../parser.c", "-I", ".."]
+compile_args = ["-c", "-fpic", "-flto=auto", "../parser.c", "../scanner.c", "-I", ".."]
 compile_flags = ["-O3"]
 link = "cc"
-link_args = ["-shared", "-fpic", "parser.o", "-o", "julia.so"]
+link_args = ["-shared", "-fpic", "-flto=auto", "parser.o", "scanner.o", "-o", "julia.so"]
 link_flags = ["-O3"]
 
 [language.julia.queries]


### PR DESCRIPTION
I tested that `ktsctl` works
```sh
> ktsctl -fci julia
fetching grammar for language julia
Cloning into '/run/user/1000/ktsctl/grammars/julia'...
remote: Enumerating objects: 673, done.
remote: Counting objects: 100% (303/303), done.
remote: Compressing objects: 100% (105/105), done.
remote: Total 673 (delta 256), reused 222 (delta 195), pack-reused 370
Receiving objects: 100% (673/673), 48.64 MiB | 3.61 MiB/s, done.
Resolving deltas: 100% (409/409), done.
HEAD is now at 0c088d1 Update Cargo.toml (#86)
fetching queries for language julia
Cloning into '/run/user/1000/ktsctl/queries/julia'...
remote: Enumerating objects: 41544, done.
remote: Counting objects: 100% (11308/11308), done.
remote: Compressing objects: 100% (464/464), done.
remote: Total 41544 (delta 11007), reused 10877 (delta 10844), pack-reused 30236
Receiving objects: 100% (41544/41544), 31.46 MiB | 53.43 MiB/s, done.
Resolving deltas: 100% (29119/29119), done.
HEAD is now at dbd248fd add config option for instant completion entry preview (defaulting to true).
compiling grammar for language julia
installing grammar for language julia
installing queries for language julia
```
However, I still don't actually get tree-sitter powered syntax highlighting for Julia.
Manually running `:kak-tree-sitter-req-highlight-buffer`, I get
> unsupported language: julia
https://github.com/phaazon/kak-tree-sitter/blob/50de99cf9675629665f98737042b903a87ad5305/kak-tree-sitter/src/handler.rs#L81

I already copied my modified config above into `~/.config/kak-tree-sitter/config.toml`.

I copied the query path from json after confirming the helix dir exists
https://github.com/helix-editor/helix/tree/dbd248fdfa680373d94fbc10094a160aafa0f7a7/runtime/queries/julia
https://github.com/helix-editor/helix/tree/master/runtime/queries/julia
but accidentally left the path `runtime/queries/json` the first time I ran `ktsctl`.
Not sure where it installed things to, but maybe that's causing my failure?
I did not wipe anything but simply reran `ktsctl -fci julia` after noticing my mistake, and found it didn't fix the problem.

I did confirm that a cpp file is now very colorful, so it does seem to be an issue specific to my attempt to get Julia to work, rather than a problem with `kak-tree-sitter` itself.
Julia's syntax highlighting is quite lacking out of the box (e.g., macros aren't highlighted specially), and I was hoping/suspect tree-sitter would be the easiest route to addressing that.

P.S. your blog is part of why I switched to kak from emacs.