### PR TITLE
-lstdc++ for ruby

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -792,7 +792,7 @@ compile_args = ["-c", "-fpic", "../scanner.cc", "../parser.c", "-I", ".."]
 compile_flags = ["-O3"]
 link = "c++"
 link_args = ["-shared", "-fpic", "scanner.o", "parser.o", "-o", "ruby.so"]
-link_flags = ["-O3"]
+link_flags = ["-O3", "-lstdc++"]
 
 [language.ruby.queries]
 url = "https://github.com/helix-editor/helix"


### PR DESCRIPTION
I didn't actually test this or confirm the presence of a `.cc` file, just noticed the `.cc` without linking the c++ standard library.

Also, are these portable? Mac probably would want `-lc++` (the llvm std lib)?