### PR TITLE
Fix blocking Kakoune after stopping KTS.

### DIFF
--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -62,6 +62,8 @@ define-command kak-tree-sitter-req-stop -docstring 'Ask the daemon to shutdown' 
   }
 
   remove-hooks global kak-tree-sitter
+  set-option global kts_buf_fifo_path '/dev/null'
+  set-option global kts_cmd_fifo_path '/dev/null'
 
   nop %sh{
     kak-tree-sitter -r '{ "type": "shutdown" }'


### PR DESCRIPTION
If a KTS command was invoked manually after KTS was closed, it would completely freeze the session, because of the FIFO (no one on the other side, since writes are blocking.

Relates and fixes #173.