### PR TITLE
Remove colored in kak-tree-sitter.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -292,7 +292,6 @@ name = "kak-tree-sitter"
 version = "0.4.6-dev"
 dependencies = [
  "clap",
- "colored",
  "ctrlc",
  "daemonize",
  "dirs",

--- a/kak-tree-sitter/Cargo.toml
+++ b/kak-tree-sitter/Cargo.toml
@@ -14,7 +14,6 @@ rust-version = "1.65.0"
 
 [dependencies]
 clap = { version = "4.4.8", features = ["derive"] }
-colored = "2.0.4"
 ctrlc = "3.4.1"
 daemonize = "0.5.0"
 dirs = "5.0.0"

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,4 +1,3 @@
-use colored::Colorize;
 use kak_tree_sitter_config::Config;
 
 use crate::{
@@ -43,7 +42,7 @@ impl Handler {
     let supported = self.langs.get(lang).is_some();
 
     if !supported {
-      log::warn!("{}", format!("language {lang} is not supported").red());
+      log::warn!("language {lang} is not supported");
     }
 
     Ok(Response::FiletypeSupported { supported })

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -13,7 +13,6 @@ mod session;
 
 use clap::Parser;
 use cli::Cli;
-use colored::Colorize;
 use error::OhNo;
 use kak_tree_sitter_config::Config;
 use logging::Verbosity;
@@ -22,7 +21,7 @@ use server::Server;
 
 fn main() {
   if let Err(err) = start() {
-    eprintln!("{}", err.to_string().red());
+    eprintln!("{err}");
     std::process::exit(1);
   }
 }

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -19,7 +19,6 @@ use std::{
   thread::{spawn, JoinHandle},
 };
 
-use colored::Colorize;
 use kak_tree_sitter_config::Config;
 use mio::{net::UnixListener, unix::SourceFd, Events, Interest, Poll, Token, Waker};
 
@@ -659,7 +658,7 @@ impl FifoHandler {
       },
 
       Err(err) => {
-        log::error!("malformed request: {}", format!("{err}").red());
+        log::error!("malformed request: {err}");
       }
     }
 


### PR DESCRIPTION
We are already using `log`, it’s enough.