### PR TITLE
Add remove_default_highlighter option. #141

### DIFF
--- a/kak-tree-sitter-config/src/lib.rs
+++ b/kak-tree-sitter-config/src/lib.rs
@@ -63,18 +63,18 @@ impl LanguagesConfig {
   }
 
   /// Get the directory where all grammars live in.
-  pub fn get_grammars_dir(&self) -> Option<PathBuf> {
+  pub fn get_grammars_dir() -> Option<PathBuf> {
     dirs::data_dir().map(|dir| dir.join("kak-tree-sitter/grammars"))
   }
 
   /// Get the grammar path for a given language.
-  pub fn get_grammar_path(&self, lang: impl AsRef<str>) -> Option<PathBuf> {
+  pub fn get_grammar_path(lang: impl AsRef<str>) -> Option<PathBuf> {
     let lang = lang.as_ref();
     dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/grammars/{lang}.so")))
   }
 
   /// Get the queries directory for a given language.
-  pub fn get_queries_dir(&self, lang: impl AsRef<str>) -> Option<PathBuf> {
+  pub fn get_queries_dir(lang: impl AsRef<str>) -> Option<PathBuf> {
     let lang = lang.as_ref();
     dirs::data_dir().map(|dir| dir.join(format!("kak-tree-sitter/queries/{lang}")))
   }
@@ -87,6 +87,23 @@ impl LanguagesConfig {
 pub struct LanguageConfig {
   pub grammar: LanguageGrammarConfig,
   pub queries: LanguageQueriesConfig,
+  #[serde(default)]
+  pub remove_default_highlighter: RemoveDefaultHighlighter,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+pub struct RemoveDefaultHighlighter(pub bool);
+
+impl Default for RemoveDefaultHighlighter {
+  fn default() -> Self {
+    RemoveDefaultHighlighter(true)
+  }
+}
+
+impl RemoveDefaultHighlighter {
+  pub fn to_bool(self) -> bool {
+    self.0
+  }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -99,12 +99,6 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
 # This command does a couple of things, among removing the « default » highlighting (Kakoune based) of the buffer and
 # installing some hooks to automatically highlight the buffer.
 define-command -hidden kak-tree-sitter-highlight-enable -docstring 'Enable tree-sitter highlighting for this buffer' %{
-  # remove regular highlighting, if any; we wrap this with try %{} because the highlighter might not even exist or is
-  # named differently; in such a case we should probably have a mapping or something
-  try %{
-    remove-highlighter "window/%opt{filetype}"
-  }
-
   # Add the tree-sitter highlighter
   add-highlighter -override buffer/kak-tree-sitter-highlighter ranges kts_highlighter_ranges
 

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -33,19 +33,26 @@ impl Handler {
   pub fn handle_try_enable_highlight(
     &mut self,
     session_name: impl AsRef<str>,
-    lang: &str,
+    lang_name: &str,
   ) -> Result<Response, OhNo> {
     let session_name = session_name.as_ref();
 
-    log::info!("try enable highlight for language {lang}, session {session_name}");
+    log::info!("try enable highlight for language {lang_name}, session {session_name}");
 
-    let supported = self.langs.get(lang).is_some();
+    let lang = self.langs.get(lang_name);
+    let supported = lang.is_some();
+    let remove_default_highlighter = lang
+      .map(|lang| lang.remove_default_highlighter)
+      .unwrap_or_default();
 
     if !supported {
-      log::warn!("language {lang} is not supported");
+      log::warn!("language {lang_name} is not supported");
     }
 
-    Ok(Response::FiletypeSupported { supported })
+    Ok(Response::FiletypeSupported {
+      supported,
+      remove_default_highlighter,
+    })
   }
 
   pub fn handle_highlight(

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -26,7 +26,10 @@ pub enum Response {
   Deinit,
 
   /// Whether a filetype is supported.
-  FiletypeSupported { supported: bool },
+  FiletypeSupported {
+    supported: bool,
+    remove_default_highlighter: bool,
+  },
 
   /// Highlights.
   ///
@@ -68,9 +71,19 @@ impl Response {
 
       Response::Deinit => "kak-tree-sitter-deinit".to_owned(),
 
-      Response::FiletypeSupported { supported } => {
+      Response::FiletypeSupported {
+        supported,
+        remove_default_highlighter,
+      } => {
         if *supported {
-          "kak-tree-sitter-highlight-enable".to_owned()
+          [
+            Some("kak-tree-sitter-highlight-enable"),
+            remove_default_highlighter
+              .then_some(r#"try %{ remove-highlighter "window/%opt{filetype}" }"#),
+          ]
+          .into_iter()
+          .flatten()
+          .join("\n")
         } else {
           String::new()
         }


### PR DESCRIPTION
It defaults to `true` because most of the languages look better with it, but we should also allow people not to remove the default highlighter.