### PR TITLE
Textobject selection queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "thiserror",
  "tree-sitter",
  "tree-sitter-highlight",
+ "tree-sitter-rust",
  "unicode-segmentation",
 ]
 
@@ -608,6 +609,16 @@ checksum = "042342584c5a7a0b833d9fc4e2bdab3f9868ddc6c4b339a1e01451c6720868bc"
 dependencies = [
  "regex",
  "thiserror",
+ "tree-sitter",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0832309b0b2b6d33760ce5c0e818cb47e1d72b468516bfe4134408926fa7594"
+dependencies = [
+ "cc",
  "tree-sitter",
 ]
 

--- a/kak-tree-sitter/Cargo.toml
+++ b/kak-tree-sitter/Cargo.toml
@@ -30,3 +30,6 @@ thiserror = "1.0.56"
 tree-sitter = "0.20.10"
 tree-sitter-highlight = "0.20.1"
 unicode-segmentation = "1.10.1"
+
+[dev-dependencies]
+tree-sitter-rust = "0.20.4"

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -94,11 +94,18 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
   }
 }
 
-define-command kak-tree-sitter-req-text-objects -params 1 %{
+define-command -hidden kak-tree-sitter-req-text-objects -params 1 %{
   evaluate-commands -no-hooks %{
-    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"" }"
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"", ""object_flags"": ""%val{object_flags}"", ""select_mode"": ""%val{select_mode}"" }"
     write %opt{kts_buf_fifo_path}
   }
+}
+
+define-command -hidden kak-tree-sitter-text-objects-enable %{
+    map -docstring 'function (tree-sitter)'  buffer object f   '<a-;> kak-tree-sitter-req-text-objects function<ret>'
+    map -docstring 'class (tree-sitter)'     buffer object t   '<a-;> kak-tree-sitter-req-text-objects class<ret>'
+    map -docstring 'comment (tree-sitter)'   buffer object '#' '<a-;> kak-tree-sitter-req-text-objects comment<ret>'
+    map -docstring 'parameter (tree-sitter)' buffer object 'v' '<a-;> kak-tree-sitter-req-text-objects parameter<ret>'
 }
 
 # Enable highlighting for the current buffer.
@@ -128,6 +135,7 @@ define-command -hidden kak-tree-sitter-set-lang %{
 define-command kak-tree-sitter-req-enable -docstring 'Send request to enable tree-sitter support' %{
   kak-tree-sitter-set-lang
   echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""try_enable_highlight"", ""lang"": ""%opt{kts_lang}"", ""client"": ""%val{client}"" }"
+  kak-tree-sitter-text-objects-enable
 }
 
 # Initiate request.

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -94,6 +94,13 @@ define-command kak-tree-sitter-req-highlight-buffer -docstring 'Highlight the cu
   }
 }
 
+define-command kak-tree-sitter-req-text-objects -params 1 %{
+  evaluate-commands -no-hooks %{
+    echo -to-file %opt{kts_cmd_fifo_path} -- "{ ""type"": ""text_objects"", ""client"": ""%val{client}"", ""buffer"": ""%val{bufname}"", ""lang"": ""%opt{kts_lang}"", ""timestamp"": %val{timestamp}, ""selection"": ""%val{selection_desc}"", ""textobject_type"": ""%arg{1}"" }"
+    write %opt{kts_buf_fifo_path}
+  }
+}
+
 # Enable highlighting for the current buffer.
 # 
 # This command does a couple of things, among removing the « default » highlighting (Kakoune based) of the buffer and

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -73,4 +73,7 @@ pub enum OhNo {
 
   #[error("highlight error: {err}")]
   HighlightError { err: String },
+  
+  #[error("internal server error: {err}")]
+  InternalError { err: String },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -74,6 +74,9 @@ pub enum OhNo {
   #[error("highlight error: {err}")]
   HighlightError { err: String },
   
+  #[error("textobject error: {err}")]
+  TextobjectError { err: String },
+  
   #[error("internal server error: {err}")]
   InternalError { err: String },
 }

--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -68,6 +68,9 @@ pub enum OhNo {
   #[error("cannot send request: {err}")]
   CannotSendRequest { err: String },
 
+  #[error("cannot parse buffer")]
+  CannotParseBuffer,
+
   #[error("highlight error: {err}")]
   HighlightError { err: String },
 }

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,6 +1,7 @@
-use std::collections::HashMap;
+use std::collections::{hash_map::Entry, HashMap};
 
 use kak_tree_sitter_config::Config;
+use tree_sitter::Language;
 
 use crate::{
   error::OhNo,
@@ -37,6 +38,29 @@ impl Handler {
       trees,
       langs,
     })
+  }
+
+  /// Ensure we have a parsed tree for this buffer id and buffer content.
+  fn compute_tree<'a>(
+    tree_states: &'a mut HashMap<BufferId, TreeState>,
+    lang: Language,
+    buffer_id: BufferId,
+    buf: &str,
+  ) -> Result<&'a mut TreeState, OhNo> {
+    match tree_states.entry(buffer_id) {
+      Entry::Vacant(entry) => {
+        // first time we see this buffer; full parse
+        let tree_state = TreeState::new(lang, buf)?;
+        Ok(entry.insert(tree_state))
+      }
+
+      Entry::Occupied(mut entry) => {
+        // TODO(#26): we already have a parsed buffer; we want an incremental update instead of fully reparsing everything
+        let tree_state = TreeState::new(lang, buf)?;
+        entry.insert(tree_state);
+        Ok(entry.into_mut())
+      }
+    }
   }
 
   pub fn handle_try_enable_highlight(
@@ -88,14 +112,17 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
-      // HACK: current test with the new tree-sitter implementation
-      if let Some(tree) = self.trees.get_mut(&buffer_id) {
-        tree.query(&lang.hl_config.query, buf);
-      }
+      // HACK: current test with the new tree-sitter implementation; actually, I think we shouldn’t do that here; we
+      // should require the buffer to be parsed in the first place
+      let tree_state = Self::compute_tree(&mut self.trees, lang.lang(), buffer_id, buf)?;
 
-      self
-        .highlighters
-        .highlight(lang, &self.langs, buffer_id, timestamp, buf)
+      tree_state.query(&lang.hl_config.query, buf);
+      log::info!("trying injections now…");
+      Ok(Response::status("unimplemented"))
+
+      //self
+      //  .highlighters
+      //  .highlight(lang, &self.langs, buffer_id, timestamp, buf)
     } else {
       Ok(Response::status(format!(
         "unsupported language: {lang_name}"

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,12 +1,12 @@
 use std::collections::{hash_map::Entry, HashMap};
 
 use kak_tree_sitter_config::Config;
-use tree_sitter::Language;
+use tree_sitter::Language as TSLanguage;
 
 use crate::{
   error::OhNo,
-  highlighting::{BufferId, Highlighters},
-  languages::Languages,
+  highlighting::BufferId,
+  languages::{Language, Languages},
   response::Response,
   tree_sitter_state::TreeState,
 };
@@ -16,10 +16,6 @@ use crate::{
 /// This type is stateful, as requests might have side-effect (i.e. tree-sitter parsing generates trees/highlighters
 /// that can be reused, for instance).
 pub struct Handler {
-  // TODO: should be removed and moved into `trees`
-  /// Map a highlighter to a [`BufferId`].
-  highlighters: Highlighters,
-
   /// Tree-sitter trees associated with a [`BufferId`].
   trees: HashMap<BufferId, TreeState>,
 
@@ -29,35 +25,31 @@ pub struct Handler {
 
 impl Handler {
   pub fn new(config: &Config) -> Result<Self, OhNo> {
-    let highlighters = Highlighters::new();
     let trees = HashMap::default();
     let langs = Languages::load_from_dir(config)?;
 
-    Ok(Self {
-      highlighters,
-      trees,
-      langs,
-    })
+    Ok(Self { trees, langs })
   }
 
   /// Ensure we have a parsed tree for this buffer id and buffer content.
   fn compute_tree<'a>(
     tree_states: &'a mut HashMap<BufferId, TreeState>,
-    lang: Language,
+    lang: &Language,
     buffer_id: BufferId,
     buf: &str,
   ) -> Result<&'a mut TreeState, OhNo> {
     match tree_states.entry(buffer_id) {
       Entry::Vacant(entry) => {
         // first time we see this buffer; full parse
-        let tree_state = TreeState::new(lang, buf)?;
+        let tree_state = TreeState::new(lang)?;
         Ok(entry.insert(tree_state))
       }
 
       Entry::Occupied(mut entry) => {
-        // TODO(#26): we already have a parsed buffer; we want an incremental update instead of fully reparsing everything
-        let tree_state = TreeState::new(lang, buf)?;
-        entry.insert(tree_state);
+        if entry.get().lang() != lang.lang() {
+          entry.insert(TreeState::new(lang)?);
+        }
+        entry.get_mut().update(buf);
         Ok(entry.into_mut())
       }
     }
@@ -112,17 +104,16 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
-      // HACK: current test with the new tree-sitter implementation; actually, I think we shouldn’t do that here; we
-      // should require the buffer to be parsed in the first place
-      let tree_state = Self::compute_tree(&mut self.trees, lang.lang(), buffer_id, buf)?;
+      let tree_state = Self::compute_tree(&mut self.trees, &lang, buffer_id, buf)?;
 
-      tree_state.query(&lang.hl_config.query, buf);
-      log::info!("trying injections now…");
-      Ok(Response::status("unimplemented"))
+      // tree_state.query(&lang.hl_config.query, buf);
+      // log::info!("trying injections now…");
+      // Ok(Response::status("unimplemented"));
 
-      //self
-      //  .highlighters
-      //  .highlight(lang, &self.langs, buffer_id, timestamp, buf)
+      Ok(Response::Highlights {
+        timestamp,
+        ranges: tree_state.highlight(lang, &self.langs, buf)?,
+      })
     } else {
       Ok(Response::status(format!(
         "unsupported language: {lang_name}"

--- a/kak-tree-sitter/src/handler.rs
+++ b/kak-tree-sitter/src/handler.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use kak_tree_sitter_config::Config;
 
 use crate::{
@@ -5,6 +7,7 @@ use crate::{
   highlighting::{BufferId, Highlighters},
   languages::Languages,
   response::Response,
+  tree_sitter_state::TreeState,
 };
 
 /// Type responsible for handling requests.
@@ -12,8 +15,12 @@ use crate::{
 /// This type is stateful, as requests might have side-effect (i.e. tree-sitter parsing generates trees/highlighters
 /// that can be reused, for instance).
 pub struct Handler {
+  // TODO: should be removed and moved into `trees`
   /// Map a highlighter to a [`BufferId`].
   highlighters: Highlighters,
+
+  /// Tree-sitter trees associated with a [`BufferId`].
+  trees: HashMap<BufferId, TreeState>,
 
   /// Known languages.
   langs: Languages,
@@ -22,10 +29,12 @@ pub struct Handler {
 impl Handler {
   pub fn new(config: &Config) -> Result<Self, OhNo> {
     let highlighters = Highlighters::new();
+    let trees = HashMap::default();
     let langs = Languages::load_from_dir(config)?;
 
     Ok(Self {
       highlighters,
+      trees,
       langs,
     })
   }
@@ -79,6 +88,11 @@ impl Handler {
     buf: &str,
   ) -> Result<Response, OhNo> {
     if let Some(lang) = self.langs.get(lang_name) {
+      // HACK: current test with the new tree-sitter implementation
+      if let Some(tree) = self.trees.get_mut(&buffer_id) {
+        tree.query(&lang.hl_config.query, buf);
+      }
+
       self
         .highlighters
         .highlight(lang, &self.langs, buffer_id, timestamp, buf)

--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -231,6 +231,7 @@ where
 
 #[cfg(test)]
 mod tests {
+  use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
   use unicode_segmentation::UnicodeSegmentation;
 
   use super::ByteLineColMapper;
@@ -345,5 +346,113 @@ mod tests {
     mapper.advance(3);
     assert_eq!(mapper.line(), 2);
     assert_eq!(mapper.col_byte(), 0);
+  }
+
+  #[test]
+  fn kak_hl_ranges_from_iter() {
+    let source = "fn foo(a: i32, b: /* ® */ impl Into<Option<String>>) {}";
+    let hl_names = vec![
+      "constant",
+      "function",
+      "keyword",
+      "variable",
+      "punctuation",
+      "type",
+      "comment",
+    ];
+
+    let mut hl_conf = HighlightConfiguration::new(
+      tree_sitter_rust::language(),
+      tree_sitter_rust::HIGHLIGHT_QUERY,
+      tree_sitter_rust::INJECTIONS_QUERY,
+      "",
+    )
+    .unwrap();
+    hl_conf.configure(&hl_names);
+
+    let mut hl = Highlighter::new();
+    let events: Vec<_> = hl
+      .highlight(&hl_conf, source.as_bytes(), None, |_| None)
+      .unwrap()
+      .flatten()
+      .collect();
+
+    assert_eq!(events.len(), 70);
+
+    assert!(matches!(
+      events[..],
+      [
+        HighlightEvent::HighlightStart(Highlight(2)),
+        HighlightEvent::Source { start: 0, end: 2 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 2, end: 3 },
+        HighlightEvent::HighlightStart(Highlight(1)),
+        HighlightEvent::Source { start: 3, end: 6 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 6, end: 7 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(3)),
+        HighlightEvent::Source { start: 7, end: 8 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 8, end: 9 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 9, end: 10 },
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 10, end: 13 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 13, end: 14 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 14, end: 15 },
+        HighlightEvent::HighlightStart(Highlight(3)),
+        HighlightEvent::Source { start: 15, end: 16 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 16, end: 17 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 17, end: 18 },
+        HighlightEvent::HighlightStart(Highlight(6)),
+        HighlightEvent::Source { start: 18, end: 26 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 26, end: 27 },
+        HighlightEvent::HighlightStart(Highlight(2)),
+        HighlightEvent::Source { start: 27, end: 31 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 31, end: 32 },
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 32, end: 36 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 36, end: 37 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 37, end: 43 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 43, end: 44 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(5)),
+        HighlightEvent::Source { start: 44, end: 50 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 50, end: 51 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 51, end: 52 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 52, end: 53 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::Source { start: 53, end: 54 },
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 54, end: 55 },
+        HighlightEvent::HighlightEnd,
+        HighlightEvent::HighlightStart(Highlight(4)),
+        HighlightEvent::Source { start: 55, end: 56 },
+        HighlightEvent::HighlightEnd
+      ]
+    ));
   }
 }

--- a/kak-tree-sitter/src/highlighting.rs
+++ b/kak-tree-sitter/src/highlighting.rs
@@ -1,6 +1,6 @@
 //! Convert from tree-sitter-highlight events to Kakoune ranges highlighter.
 
-use std::collections::HashMap;
+
 
 use serde::{Deserialize, Serialize};
 use tree_sitter_highlight::{Highlight, HighlightEvent, Highlighter};
@@ -9,7 +9,6 @@ use unicode_segmentation::UnicodeSegmentation;
 use crate::{
   error::OhNo,
   languages::{Language, Languages},
-  response::Response,
 };
 
 /// A unique way to identify a buffer.

--- a/kak-tree-sitter/src/kak.rs
+++ b/kak-tree-sitter/src/kak.rs
@@ -1,0 +1,115 @@
+use std::ops::Range;
+
+use serde::Deserialize;
+
+/// Kakoune location. Line and col_byte are zero indexed here,
+/// but one indexed when formatted and parsed
+#[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+pub struct Loc {
+  pub line: usize,
+  pub col_byte: usize,
+}
+
+impl std::fmt::Display for Loc {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}.{}", self.line + 1, self.col_byte + 1)
+  }
+}
+
+impl From<tree_sitter::Point> for Loc {
+  fn from(value: tree_sitter::Point) -> Self {
+    // The tree_sitter::Point column is also a byte offset, so this is ok
+    Self {
+      line: value.row,
+      col_byte: value.column,
+    }
+  }
+}
+
+impl From<Loc> for tree_sitter::Point {
+  fn from(value: Loc) -> Self {
+    Self {
+      row: value.line,
+      column: value.col_byte,
+    }
+  }
+}
+
+impl Loc {
+  pub fn new(line: usize, col_byte: usize) -> Self {
+    Self { line, col_byte }
+  }
+
+  /// Parse a location from kakoune in the format line.col
+  pub fn parse(s: &str) -> Option<Self> {
+    let (line, col) = s.split_once('.')?;
+    Some(Self {
+      line: line.parse::<usize>().ok()?.saturating_sub(1),
+      col_byte: col.parse::<usize>().ok()?.saturating_sub(1),
+    })
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocRange {
+  pub start: Loc,
+  pub end: Loc,
+}
+
+impl<T: Into<Loc>> From<Range<T>> for LocRange {
+  fn from(value: Range<T>) -> Self {
+    Self {
+      start: value.start.into(),
+      end: value.end.into(),
+    }
+  }
+}
+
+impl LocRange {
+  pub fn new(start: Loc, end: Loc) -> Self {
+    Self { start, end }
+  }
+
+  pub fn contains(&self, loc: Loc) -> bool {
+    loc >= self.start && loc <= self.end
+  }
+
+  pub fn contains_range(&self, range: &LocRange) -> bool {
+    self.contains(range.start) && self.contains(range.end)
+  }
+
+  /// Parse a location from kakoune in the format `a.b,c.d`, where start.line = a, start.col = b, end.line = c, end.col = d
+  pub fn parse_selection(s: &str) -> Option<Self> {
+    let (start, end) = s.split_once(',')?;
+    Some(Self {
+      start: Loc::parse(start)?,
+      end: Loc::parse(end)?,
+    })
+  }
+}
+
+impl std::fmt::Display for LocRange {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{},{}", self.start, self.end)
+  }
+}
+
+impl<'de> Deserialize<'de> for LocRange {
+  fn deserialize<D>(deserializer: D) -> Result<LocRange, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    use serde::de::Error;
+    let s = <&str>::deserialize(deserializer)?;
+    LocRange::parse_selection(s).ok_or(D::Error::custom("Could not parse LocRange"))
+  }
+}
+
+impl serde::Serialize for LocRange {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    self.to_string().serialize(serializer)
+  }
+}

--- a/kak-tree-sitter/src/kak.rs
+++ b/kak-tree-sitter/src/kak.rs
@@ -50,47 +50,65 @@ impl Loc {
   }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LocRange {
-  pub start: Loc,
-  pub end: Loc,
+  pub anchor: Loc,
+  pub cursor: Loc,
 }
 
 impl<T: Into<Loc>> From<Range<T>> for LocRange {
   fn from(value: Range<T>) -> Self {
     Self {
-      start: value.start.into(),
-      end: value.end.into(),
+      anchor: value.start.into(),
+      cursor: value.end.into(),
     }
   }
 }
 
 impl LocRange {
-  pub fn new(start: Loc, end: Loc) -> Self {
-    Self { start, end }
+  pub fn new(anchor: Loc, cursor: Loc) -> Self {
+    Self { anchor, cursor }
   }
 
   pub fn contains(&self, loc: Loc) -> bool {
-    loc >= self.start && loc <= self.end
+    loc >= self.start() && loc <= self.end()
   }
 
   pub fn contains_range(&self, range: &LocRange) -> bool {
-    self.contains(range.start) && self.contains(range.end)
+    self.contains(range.cursor) && self.contains(range.anchor)
   }
 
   /// Parse a location from kakoune in the format `a.b,c.d`, where start.line = a, start.col = b, end.line = c, end.col = d
   pub fn parse_selection(s: &str) -> Option<Self> {
-    let (start, end) = s.split_once(',')?;
+    let (anchor, cursor) = s.split_once(',')?;
     Some(Self {
-      start: Loc::parse(start)?,
-      end: Loc::parse(end)?,
+      anchor: Loc::parse(anchor)?,
+      cursor: Loc::parse(cursor)?,
     })
+  }
+
+  pub fn start(&self) -> Loc {
+    self.cursor.min(self.anchor)
+  }
+
+  pub fn end(&self) -> Loc {
+    self.cursor.max(self.anchor)
+  }
+
+  /// Merge two selections, keeping the order of the cursor/anchor. i.e. if the cursor was at the start of the
+  /// selection before, keep it at the start of the selection after
+  pub fn extend(&self, other: LocRange) -> LocRange {
+    if self.anchor < self.cursor {
+      LocRange::new(self.start().min(other.start()), self.end().max(other.end()))
+    } else {
+      LocRange::new(self.end().max(other.end()), self.start().min(other.start()))
+    }
   }
 }
 
 impl std::fmt::Display for LocRange {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{},{}", self.start, self.end)
+    write!(f, "{},{}", self.anchor, self.cursor)
   }
 }
 
@@ -112,4 +130,47 @@ impl serde::Serialize for LocRange {
   {
     self.to_string().serialize(serializer)
   }
+}
+
+/// The flags stored in kakoune's %val{object_flags}
+#[derive(Debug, Default, Clone, Copy, serde::Serialize)]
+pub struct ObjectFlags {
+  pub to_begin: bool,
+  pub to_end: bool,
+  pub inner: bool,
+}
+
+impl ObjectFlags {
+  pub fn parse(s: &str) -> Self {
+    let mut res = Self::default();
+    for flag in s.split('|') {
+      match flag {
+        "inner" => res.inner = true,
+        "to_begin" => res.to_begin = true,
+        "to_end" => res.to_end = true,
+        _ => log::warn!("Unexpected object flag from kakoune: {flag}"),
+      }
+    }
+    res
+  }
+}
+
+impl<'de> Deserialize<'de> for ObjectFlags {
+  fn deserialize<D>(deserializer: D) -> Result<ObjectFlags, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let s = <&str>::deserialize(deserializer)?;
+    Ok(ObjectFlags::parse(s))
+  }
+}
+
+/// The selection mode stored in %val{select_mode}
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+pub enum SelectMode {
+  #[default]
+  #[serde(rename = "replace")]
+  Replace,
+  #[serde(rename = "extend")]
+  Extend,
 }

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, path::Path};
 
 use kak_tree_sitter_config::{Config, LanguagesConfig};
 use libloading::Symbol;
+use tree_sitter::Query;
 use tree_sitter_highlight::HighlightConfiguration;
 
 use crate::{error::OhNo, queries::Queries};
@@ -15,6 +16,8 @@ pub struct Language {
   pub hl_names: Vec<String>,
   // whether we should remove the default highlighter when highlighting a buffer with this language
   pub remove_default_highlighter: bool,
+  pub textobjects_query: Option<Query>,
+  pub indents_query: Option<Query>,
 
   // NOTE: we need to keep that alive *probably*; better be safe than sorry
   ts_lang: tree_sitter::Language,
@@ -102,6 +105,14 @@ impl Languages {
             remove_default_highlighter,
             ts_lang,
             _ts_lib: ts_lib,
+            textobjects_query: queries
+              .textobjects
+              .as_deref()
+              .and_then(|x| Query::new(ts_lang, x).ok()),
+            indents_query: queries
+              .indents
+              .as_deref()
+              .and_then(|x| Query::new(ts_lang, x).ok()),
           };
           langs.insert(lang_name.to_owned(), lang);
         }

--- a/kak-tree-sitter/src/languages.rs
+++ b/kak-tree-sitter/src/languages.rs
@@ -17,8 +17,14 @@ pub struct Language {
   pub remove_default_highlighter: bool,
 
   // NOTE: we need to keep that alive *probably*; better be safe than sorry
-  _ts_lang: tree_sitter::Language,
+  ts_lang: tree_sitter::Language,
   _ts_lib: libloading::Library,
+}
+
+impl Language {
+  pub fn lang(&self) -> tree_sitter::Language {
+    self.ts_lang
+  }
 }
 
 pub struct Languages {
@@ -94,7 +100,7 @@ impl Languages {
             hl_config,
             hl_names,
             remove_default_highlighter,
-            _ts_lang: ts_lang,
+            ts_lang,
             _ts_lib: ts_lib,
           };
           langs.insert(lang_name.to_owned(), lang);

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -10,6 +10,7 @@ mod request;
 mod response;
 mod server;
 mod session;
+mod tree_sitter_state;
 
 use clap::Parser;
 use cli::Cli;

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -11,6 +11,7 @@ mod response;
 mod server;
 mod session;
 mod tree_sitter_state;
+mod kak;
 
 use clap::Parser;
 use cli::Cli;

--- a/kak-tree-sitter/src/queries.rs
+++ b/kak-tree-sitter/src/queries.rs
@@ -7,7 +7,8 @@ pub struct Queries {
   pub highlights: Option<String>,
   pub injections: Option<String>,
   pub locals: Option<String>,
-  pub text_objects: Option<String>,
+  pub textobjects: Option<String>,
+  pub indents: Option<String>,
 }
 
 impl Queries {
@@ -17,13 +18,15 @@ impl Queries {
     let highlights = fs::read_to_string(dir.join("highlights.scm")).ok();
     let injections = fs::read_to_string(dir.join("injections.scm")).ok();
     let locals = fs::read_to_string(dir.join("locals.scm")).ok();
-    let text_objects = fs::read_to_string(dir.join("text_objects.scm")).ok();
+    let textobjects = fs::read_to_string(dir.join("textobjects.scm")).ok();
+    let indents = fs::read_to_string(dir.join("indents.scm")).ok();
 
     Queries {
       highlights,
       injections,
       locals,
-      text_objects,
+      textobjects,
+      indents,
     }
   }
 }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -66,10 +66,12 @@ pub enum Request {
     buffer: String,
     lang: String,
     timestamp: u64,
-    /// Which textobject to look for. Format: {type,function,parameter,comment}.{inside,around}
+    /// Which textobject to look for, i.e.  type,function,parameter,comment
     textobject_type: String,
     /// Will return the smallest matching textobject that contains this selection
     selection: kak::LocRange,
+    object_flags: kak::ObjectFlags,
+    select_mode: kak::SelectMode,
   },
 }
 

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -39,7 +39,7 @@ impl UnixRequest {
 /// Request payload.
 ///
 /// Request payload are parameterized with the « origin » at which requests are expected.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Request {
   /// Try enabling highlighting for a given filetype.

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -4,6 +4,8 @@ use std::fmt::Debug;
 
 use serde::{Deserialize, Serialize};
 
+use crate::kak;
+
 /// Unidentified request (i.e. not linked to a given session).
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -58,6 +60,17 @@ pub enum Request {
     lang: String,
     timestamp: u64,
   },
+
+  TextObjects {
+    client: String,
+    buffer: String,
+    lang: String,
+    timestamp: u64,
+    /// Which textobject to look for. Format: {type,function,parameter,comment}.{inside,around}
+    textobject_type: String,
+    /// Will return the smallest matching textobject that contains this selection
+    selection: kak::LocRange,
+  },
 }
 
 impl Request {
@@ -65,6 +78,7 @@ impl Request {
     match self {
       Request::TryEnableHighlight { client, .. } => Some(client.as_str()),
       Request::Highlight { client, .. } => Some(client.as_str()),
+      Request::TextObjects { client, .. } => Some(client.as_str()),
     }
   }
 }

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use itertools::Itertools;
 
 use crate::highlighting::KakHighlightRange;
+use crate::kak;
 
 /// Response sent by the daemon to Kakoune.
 #[derive(Debug, Eq, PartialEq)]
@@ -37,6 +38,12 @@ pub enum Response {
   Highlights {
     timestamp: u64,
     ranges: Vec<KakHighlightRange>,
+  },
+
+  TextObject {
+    timestamp: u64,
+    obj_type: String,
+    range: kak::LocRange,
   },
 }
 
@@ -99,6 +106,14 @@ impl Response {
           "{range_specs} {timestamp} {ranges_str}",
           range_specs = "set buffer kts_highlighter_ranges",
         )
+      }
+
+      Response::TextObject {
+        timestamp,
+        obj_type,
+        range,
+      } => {
+        format!("select -timestamp {timestamp} {range}")
       }
     };
 

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -21,6 +21,7 @@ use std::{
 
 use kak_tree_sitter_config::Config;
 use mio::{net::UnixListener, unix::SourceFd, Events, Interest, Poll, Token, Waker};
+use serde::Deserialize;
 
 use crate::{
   cli::Cli,
@@ -646,36 +647,38 @@ impl FifoHandler {
 
     log::info!("FIFO request: {buffer}");
 
-    let req = serde_json::from_str::<Request>(buffer).map_err(|err| OhNo::InvalidRequest {
-      req: buffer.clone(),
-      err: err.to_string(),
-    });
+    let mut de = serde_json::Deserializer::from_str(buffer);
+    while de.end().is_err() {
+      let req = Request::deserialize(&mut de).map_err(|err| OhNo::InvalidRequest {
+        req: buffer.clone(),
+        err: err.to_string(),
+      });
 
-    buffer.clear();
+      match req {
+        Ok(req) => match self.process_cmd(session, &req) {
+          Ok(Some(resp)) => {
+            let client = req.client_name();
+            let conn_resp =
+              ConnectedResponse::new(session.name(), client.map(|c| c.to_owned()), resp);
 
-    match req {
-      Ok(req) => match self.process_cmd(session, &req) {
-        Ok(Some(resp)) => {
-          let client = req.client_name();
-          let conn_resp =
-            ConnectedResponse::new(session.name(), client.map(|c| c.to_owned()), resp);
-
-          if let Err(err) = self.resp_sender.send(conn_resp) {
-            log::error!("failure while sending response: {err}");
+            if let Err(err) = self.resp_sender.send(conn_resp) {
+              log::error!("failure while sending response: {err}");
+            }
           }
-        }
+
+          Err(err) => {
+            log::error!("handling request failed: {err}");
+          }
+
+          _ => (),
+        },
 
         Err(err) => {
-          log::error!("handling request failed: {err}");
+          log::error!("malformed request: {err}");
         }
-
-        _ => (),
-      },
-
-      Err(err) => {
-        log::error!("malformed request: {err}");
       }
     }
+    buffer.clear();
 
     Ok(())
   }
@@ -773,10 +776,16 @@ impl FifoHandler {
         lang,
         timestamp,
         textobject_type,
-        selection, 
-      } => self
-        .handler
-        .handle_text_objects(session.name(), &buffer, &lang, timestamp, buf, selection, textobject_type),
+        selection,
+      } => self.handler.handle_text_objects(
+        session.name(),
+        &buffer,
+        &lang,
+        timestamp,
+        buf,
+        selection,
+        textobject_type,
+      ),
       _ => Err(OhNo::InternalError {
         err: format!("Unexpected request type was waiting for buffer: {req:?}"),
       }),

--- a/kak-tree-sitter/src/session.rs
+++ b/kak-tree-sitter/src/session.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs::File, mem::replace};
+use std::{collections::HashMap, fs::File};
 
 use mio::Token;
 
@@ -148,9 +148,11 @@ impl SessionState {
 
   /// If a request is waiting for the buffer content, take it, and reset the state to idle
   pub fn take_waiting_req(&mut self) -> Option<Request> {
-    if let SessionState::WaitingForBuf(req) = self {
+    if let SessionState::WaitingForBuf(_req) = self {
       let oldself = std::mem::replace(self, SessionState::Idle);
-      let SessionState::WaitingForBuf(req) = oldself;
+      let SessionState::WaitingForBuf(req) = oldself else {
+        unreachable!()
+      };
       Some(req)
     } else {
       None

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -66,21 +66,18 @@ impl TreeState {
     crate::highlighting::highlight(&mut self.highlighter, lang, langs, source)
   }
 
-  pub fn query(&self, query: &Query, code: &str) {
-    let mut cursor = QueryCursor::new();
-    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
-    let names = query.capture_names();
+  pub fn tree(&self) -> &tree_sitter::Tree {
+    &self.tree
+  }
 
-    for (query_match, size) in captures {
-      for capture in query_match.captures {
-        log::info!(
-          "--> {}: {:#?} {:?} // {:?}",
-          &code[capture.node.byte_range()],
-          capture.node.kind(),
-          names.get(capture.index as usize),
-          capture
-        );
-      }
-    }
+  pub fn query<'a>(
+    &'a self,
+    cursor: &'a mut QueryCursor,
+    query: &'a Query,
+    code: &'a str,
+  ) -> impl Iterator<Item = &'a tree_sitter::QueryCapture<'a>> {
+    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+
+    captures.flat_map(|(qm, _size)| qm.captures)
   }
 }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,27 +1,43 @@
 //! Tree-sitter state (i.e. highlighting, tree walking, etc.)
 
-use tree_sitter::{Query, QueryCursor};
+use tree_sitter::{Language, Parser, Query, QueryCursor};
+
+use crate::error::OhNo;
 
 /// State around a tree.
 ///
-/// A tree-sitter tree represents a parsed buffer in a given state. It can walked with queries and updated.
+/// A tree-sitter tree represents a parsed buffer in a given state. It can be walked with queries and updated.
 #[derive(Debug)]
 pub struct TreeState {
   tree: tree_sitter::Tree,
 }
 
 impl TreeState {
-  pub fn new(tree: tree_sitter::Tree) -> Self {
-    Self { tree }
+  pub fn new(lang: Language, buf: &str) -> Result<Self, OhNo> {
+    let mut parser = Parser::new();
+    parser.set_language(lang);
+    parser.set_timeout_micros(1000);
+
+    parser
+      .parse(buf.as_bytes(), None)
+      .ok_or(OhNo::CannotParseBuffer)
+      .map(|tree| Self { tree })
   }
 
   pub fn query(&self, query: &Query, code: &str) {
     let mut cursor = QueryCursor::new();
     let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+    let names = query.capture_names();
 
     for (query_match, size) in captures {
       for capture in query_match.captures {
-        log::info!("--> {:?}", capture);
+        log::info!(
+          "--> {}: {:#?} {:?} // {:?}",
+          &code[capture.node.byte_range()],
+          capture.node.kind(),
+          names.get(capture.index as usize),
+          capture
+        );
       }
     }
   }

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,0 +1,28 @@
+//! Tree-sitter state (i.e. highlighting, tree walking, etc.)
+
+use tree_sitter::{Query, QueryCursor};
+
+/// State around a tree.
+///
+/// A tree-sitter tree represents a parsed buffer in a given state. It can walked with queries and updated.
+#[derive(Debug)]
+pub struct TreeState {
+  tree: tree_sitter::Tree,
+}
+
+impl TreeState {
+  pub fn new(tree: tree_sitter::Tree) -> Self {
+    Self { tree }
+  }
+
+  pub fn query(&self, query: &Query, code: &str) {
+    let mut cursor = QueryCursor::new();
+    let captures = cursor.captures(query, self.tree.root_node(), code.as_bytes());
+
+    for (query_match, size) in captures {
+      for capture in query_match.captures {
+        log::info!("--> {:?}", capture);
+      }
+    }
+  }
+}

--- a/kak-tree-sitter/src/tree_sitter_state.rs
+++ b/kak-tree-sitter/src/tree_sitter_state.rs
@@ -1,27 +1,69 @@
 //! Tree-sitter state (i.e. highlighting, tree walking, etc.)
 
-use tree_sitter::{Language, Parser, Query, QueryCursor};
+use tree_sitter::{Language as TSLanguage, Parser, Query, QueryCursor};
+use tree_sitter_highlight::Highlighter;
 
 use crate::error::OhNo;
+use crate::highlighting::KakHighlightRange;
+use crate::languages::Language;
+use crate::languages::Languages;
 
 /// State around a tree.
 ///
 /// A tree-sitter tree represents a parsed buffer in a given state. It can be walked with queries and updated.
-#[derive(Debug)]
 pub struct TreeState {
+  highlighter: Highlighter,
+  parser: Parser,
   tree: tree_sitter::Tree,
 }
 
 impl TreeState {
-  pub fn new(lang: Language, buf: &str) -> Result<Self, OhNo> {
+  pub fn new(lang: &Language) -> Result<Self, OhNo> {
     let mut parser = Parser::new();
-    parser.set_language(lang);
+    parser.set_language(lang.lang());
     parser.set_timeout_micros(1000);
 
-    parser
+    let highlighter = Highlighter::new();
+
+    let tree = parser.parse("", None).unwrap();
+
+    Ok(Self {
+      highlighter,
+      parser,
+      tree,
+    })
+  }
+
+  pub fn parser_mut(&mut self) -> &mut Parser {
+    // TODO: Can this be merged with the highlighters parser?
+    &mut self.parser
+  }
+
+  pub fn parser(&self) -> &Parser {
+    // TODO: Can this be merged with the highlighters parser?
+    &self.parser
+  }
+
+  pub fn lang(&self) -> TSLanguage {
+    self.parser.language().unwrap() // Is set in constructor
+  }
+
+  pub fn update(&mut self, buf: &str) -> Result<(), OhNo> {
+    self.tree = self
+      .parser
       .parse(buf.as_bytes(), None)
-      .ok_or(OhNo::CannotParseBuffer)
-      .map(|tree| Self { tree })
+      .ok_or(OhNo::CannotParseBuffer)?;
+    Ok(())
+  }
+
+  pub fn highlight(
+    &mut self,
+    lang: &Language,
+    langs: &Languages,
+    source: &str,
+  ) -> Result<Vec<KakHighlightRange>, OhNo> {
+    // TODO: Merge this logic with the one parser
+    crate::highlighting::highlight(&mut self.highlighter, lang, langs, source)
   }
 
   pub fn query(&self, query: &Query, code: &str) {


### PR DESCRIPTION
First of all, sorry for the big refactors in unorganized commits

I based this on the `rewrite-tree-sitter-only` branch, as it included the beginings of some structures that are useful for this. I looked at doing highlighting with the same parser, but i think we would need to copy out most of `tree-sitter-highlight` to do that (which is what helix has done as well). This does however reuse the same parser for the document, so there is only two parsers per document.

I think this could also be the beginning of supporting incremental buffer updates. Kakoune should expose enough information to do this, and i think a generic system checking the timestamps and requesting a new buffer if it has changed would work.

Anyway, the main feature:

[![asciicast](https://asciinema.org/a/G8bYndRR6lDUiRiVczU2XLvb7.svg)](https://asciinema.org/a/G8bYndRR6lDUiRiVczU2XLvb7)

```
kak-tree-sitter-req-text-objects function.around
```

Current caveats:
 - there are no default mappings
 - it only supports one type of text object per call (i.e. no kak-tree-sitter-req-text-objects *.around)
 - It only supports extending the selection - no "forward to next function"
 - It cannot (easily) be used with the existing text objects as the reply comes asynchronously.
 - There is no command to list available text object types for a language

But, with some mappings, it is simple and works reliably.


Oh, and again, sorry for the giant single PR. I also fixed a bug where the request parser would fail if more than one request arrived at the same time. This would happen when the same buffer is open in two windows. I dont know if the way i fixed it is the best way, but now it will at least parse successive requests written to the same fifo.


Next up - indents?