### PR TITLE
Fix FIFOs / crashing KTS

### DIFF
--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -128,7 +128,7 @@ define-command kak-tree-sitter-req-enable -docstring 'Send request to enable tre
 # This is used to ask the server to tell us where to write commands and other various data.
 define-command -hidden kak-tree-sitter-req-init %{
   nop %sh{
-    kak-tree-sitter -r "{ \"type\": \"new_session\", \"name\": \"$kak_session\", \"client\": \"$kak_client\" }"
+    kak-tree-sitter -r "{ \"type\": \"register_session\", \"name\": \"$kak_session\", \"client\": \"$kak_client\" }"
   }
 }
 

--- a/kak-tree-sitter/rc/static.kak
+++ b/kak-tree-sitter/rc/static.kak
@@ -132,17 +132,17 @@ define-command -hidden kak-tree-sitter-req-init %{
   }
 }
 
-# Enable tree-sitter once we open a new window.
-hook -group kak-tree-sitter global WinCreate .* %{
-  hook -group kak-tree-sitter buffer -once WinDisplay .* kak-tree-sitter-req-enable
-}
-
-# Make kak-tree-sitter know the session has ended whenever we end it.
-hook -group kak-tree-sitter global KakEnd .* kak-tree-sitter-req-end-session
-
 # Wait to have a client and then ask the server to initiate.
 hook -group kak-tree-sitter global -once ClientCreate .* %{
-  kak-tree-sitter-req-init 
+  kak-tree-sitter-req-init
+
+  # Enable tree-sitter once we open a new window.
+  hook -group kak-tree-sitter global WinCreate .* %{
+    hook -group kak-tree-sitter buffer -once WinDisplay .* kak-tree-sitter-req-enable
+  }
+
+  # Make kak-tree-sitter know the session has ended whenever we end it.
+  hook -group kak-tree-sitter global KakEnd .* kak-tree-sitter-req-end-session
 }
 
 #set-face global ts_unknown                     red+ub

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum UnixRequest {
-  /// Inform KTS that a new session exists and that we should be sending back the Kakoune commands to get KTS features.
-  NewSession { name: String, client: String },
+  /// Inform KTS that a session exists and that we should be sending back the Kakoune commands to get KTS features.
+  RegisterSession { name: String },
 
   /// Inform KTS that a session has exited.
   SessionExit { name: String },
@@ -27,10 +27,8 @@ impl UnixRequest {
     let name = name.into();
 
     match self {
-      UnixRequest::NewSession { client, .. } => UnixRequest::NewSession { name, client },
-
+      UnixRequest::RegisterSession { .. } => UnixRequest::RegisterSession { name },
       UnixRequest::SessionExit { .. } => UnixRequest::SessionExit { name },
-
       _ => self,
     }
   }

--- a/kak-tree-sitter/src/request.rs
+++ b/kak-tree-sitter/src/request.rs
@@ -9,7 +9,10 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum UnixRequest {
   /// Inform KTS that a session exists and that we should be sending back the Kakoune commands to get KTS features.
-  RegisterSession { name: String },
+  RegisterSession {
+    name: String,
+    client: Option<String>,
+  },
 
   /// Inform KTS that a session has exited.
   SessionExit { name: String },
@@ -27,7 +30,7 @@ impl UnixRequest {
     let name = name.into();
 
     match self {
-      UnixRequest::RegisterSession { .. } => UnixRequest::RegisterSession { name },
+      UnixRequest::RegisterSession { client, .. } => UnixRequest::RegisterSession { client, name },
       UnixRequest::SessionExit { .. } => UnixRequest::SessionExit { name },
       _ => self,
     }

--- a/kak-tree-sitter/src/response.rs
+++ b/kak-tree-sitter/src/response.rs
@@ -65,7 +65,8 @@ impl Response {
           "set-option global kts_buf_fifo_path {path}",
           path = buf_fifo_path.display()
         ),
-        "kak-tree-sitter-req-enable".to_owned(),
+        // enable if we were already looking at a buffer
+        "try kak-tree-sitter-req-enable".to_owned(),
       ]
       .join("\n"),
 

--- a/kak-tree-sitter/src/server.rs
+++ b/kak-tree-sitter/src/server.rs
@@ -416,7 +416,7 @@ impl UnixHandler {
     req: UnixRequest,
   ) -> Result<Feedback, OhNo> {
     match req {
-      UnixRequest::NewSession { name, client } => {
+      UnixRequest::RegisterSession { name } => {
         let (cmd_fifo_path, buf_fifo_path) =
           self.track_session(poll, token_provider, session_tracker, name.clone())?;
 
@@ -425,7 +425,7 @@ impl UnixHandler {
           buf_fifo_path,
         };
 
-        let conn_resp = ConnectedResponse::new(name, client, resp);
+        let conn_resp = ConnectedResponse::new(name, None, resp);
         if let Err(err) = self.resp_sender.send(conn_resp) {
           log::error!("cannot send response: {err}");
         }


### PR DESCRIPTION
This PR allows several fixes to happen:

- We do not automatically clean up resources when starting up. Instead, we check whether a (live) session is associated with the data. If not, we do clean up; otherwise, we simply let the data files there and register the session again.
- That allows a crashing KTS to simply be restarted, allowing to unfreeze Kakoune.
- That also allows more control on what’s going on with sessions, especially when KTS starts while we are already looking at a buffer.