### PR TITLE
Fix getting (already existing) sessions. #235

### DIFF
--- a/kak-tree-sitter/src/error.rs
+++ b/kak-tree-sitter/src/error.rs
@@ -32,19 +32,16 @@ pub enum OhNo {
   #[error("cannot start poll: {err}")]
   CannotStartPoll { err: io::Error },
 
-  #[error("error while waiting for events: {err}")]
-  PollEventsError { err: io::Error },
+  #[error("poll error: {err}")]
+  PollError { err: io::Error },
+
+  #[error("cannot get already existing sessions: {err}")]
+  CannotGetSessions { err: String },
 
   #[error("cannot set SIGINT handler: {err}")]
   SigIntHandlerError {
     #[from]
     err: ctrlc::Error,
-  },
-
-  #[error("IO error: {err:#?}")]
-  IOError {
-    #[from]
-    err: io::Error,
   },
 
   #[error("cannot create FIFO: {err}")]

--- a/kak-tree-sitter/src/main.rs
+++ b/kak-tree-sitter/src/main.rs
@@ -21,7 +21,7 @@ use server::Server;
 
 fn main() {
   if let Err(err) = start() {
-    eprintln!("{err}");
+    log::error!("{err}");
     std::process::exit(1);
   }
 }


### PR DESCRIPTION
The previous commits introduced this (nice) feature; but if something went wrong (like no sessions when starting), we treated that as a hard error, while it really is not, since sessions will be registered and added later.